### PR TITLE
Fix wxyc-canary-check-failure alarm config to aggregate across Check dimension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Synthetic-DJ canary on AWS Lambda. Probes the WXYC user-facing API every five mi
 ## Conventions
 
 - Each check has a stable kebab-case `name` that lands in CloudWatch as a `Check` dimension. Renaming breaks pinned dashboards — pick well first time.
+- The `wxyc-canary-check-failure` alarm uses the metrics-expression form (`SUM(SEARCH(...))`) so it aggregates `CheckFailure` across every value of the `Check` dimension; a plain `MetricName` alarm queries the empty undimensioned series and sits at "no data" forever (issue #2).
 - Checks fail by **throwing**. The runner converts the throw into a `CheckOutcome` with `status: 'fail'` and the message. One throw never short-circuits the others (parallel `Promise.all` of independent try-catches).
 - `requiresAuth: true` checks downgrade to `skipped` (separate metric from `fail`) when no DJ credentials are configured. The alarm only fires on `fail`, so an operator who hasn't provisioned the DJ test account gets a noisy console but not a phone call.
 - Two credential paths: `CANARY_DJ_EMAIL` + `CANARY_DJ_PASSWORD` env vars (local + tests) or `CANARY_DJ_SECRET_ARN` pointing at a Secrets Manager secret with `{"email":"...","password":"..."}` (prod).

--- a/template.yaml
+++ b/template.yaml
@@ -106,15 +106,22 @@ Resources:
   # failure 2 of the last 3 evaluations (~10 minutes at the 5-minute schedule),
   # which avoids alerting on a single transient blip while still catching
   # sustained outages quickly.
+  #
+  # Uses the metrics-expression form (SEARCH + SUM) so the alarm aggregates
+  # CheckFailure across every value of the Check dimension. A plain
+  # Namespace/MetricName alarm without Dimensions queries the undimensioned
+  # series — which is empty, since the canary only emits CheckFailure with a
+  # Check dimension — and sits at "no data" forever (see issue #2).
   CheckFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: wxyc-canary-check-failure
       AlarmDescription: One or more WXYC canary checks have been failing.
-      Namespace: WXYC/Canary
-      MetricName: CheckFailure
-      Statistic: Maximum
-      Period: 300
+      Metrics:
+        - Id: e1
+          Expression: SUM(SEARCH('{WXYC/Canary,Check} MetricName="CheckFailure"', 'Sum', 300))
+          Label: TotalCheckFailures
+          ReturnData: true
       EvaluationPeriods: 3
       DatapointsToAlarm: 2
       Threshold: 1


### PR DESCRIPTION
## Summary

The `wxyc-canary-check-failure` alarm was configured with `Namespace` + `MetricName` + `Statistic` and no `Dimensions`, which queries the undimensioned `CheckFailure` series. The canary only emits `CheckFailure` with a `Check` dimension on every datapoint, so the alarm sat at "no data" indefinitely. During the 2026-05-01 LML FD-leak incident, 24 `proxy-library-search` failures over 2h did not trip this alarm; only the `wxyc-canary-lambda-errors` alarm fired (because the handler re-throws on any check failure, tripping the Lambda `Errors` metric).

Switch the alarm to the metrics-expression form so SUM aggregates the `CheckFailure` metric across every value of the `Check` dimension.

## What changes

- `template.yaml`: `CheckFailureAlarm` now uses `Metrics:` with a single `SUM(SEARCH('{WXYC/Canary,Check} MetricName="CheckFailure"', 'Sum', 300))` expression. `EvaluationPeriods: 3` / `DatapointsToAlarm: 2` / `Threshold: 1` / `ComparisonOperator: GreaterThanOrEqualToThreshold` / `TreatMissingData: notBreaching` / `AlarmActions` / `OKActions` are unchanged, preserving the original "any check failing 2 of 3 evaluations" intent.
- `CLAUDE.md`: one-liner under Conventions noting the metrics-expression form and why it's needed.

## Manual verification

Post-merge, after deploy:

- [ ] Confirm the alarm transitions OK -> ALARM by introducing a synthetic failure (e.g., temporarily set `CANARY_BACKEND_URL` to a 404 host, redeploy, wait `EvaluationPeriods × Period` = 15 min). Alarm should fire within that window.
- [ ] Confirm the alarm transitions ALARM -> OK by reverting `CANARY_BACKEND_URL` and redeploying. Alarm should clear within `EvaluationPeriods × Period`.
- [ ] Confirm CloudWatch console shows the alarm in OK state (not "no data") with a non-empty graph in steady state.

Closes #2