### PR TITLE
Retry sign-in once on 429 to keep transient auth blips from cascading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Synthetic-DJ canary on AWS Lambda. Probes the WXYC user-facing API every five mi
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/handler.ts`       | Lambda entry. Loads config, resolves DJ credentials (env or Secrets Manager), runs all checks in parallel, publishes per-check metrics to CloudWatch, throws if any check failed (so the Lambda Errors metric also fires). |
 | `src/checks.ts`        | The check definitions and the `signInDj` helper. One exported `checks` array. Adding a new check = one entry.                                                                                                              |
-| `src/client.ts`        | HTTP client wrapping `fetch` with a per-request `AbortController` timeout. Deliberately no retry.                                                                                                                          |
+| `src/client.ts`        | HTTP client wrapping `fetch` with a per-request `AbortController` timeout. Deliberately no retry on the surfaces being measured (a flaky retry hides brownouts).                                                            |
 | `src/types.ts`         | Codable shapes for `Check`, `CheckOutcome`, `CanaryConfig`.                                                                                                                                                                |
 | `template.yaml`        | SAM (CloudFormation) — Lambda + EventBridge schedule + SNS alert topic + three CloudWatch alarms (`wxyc-canary-check-failure`, `wxyc-canary-lambda-errors`, `wxyc-canary-mutation-4xx-surge`) + a log group.               |
 | `test/handler.test.ts` | Vitest. Mocks global `fetch` and exercises the runner end-to-end. Includes regression cases for each 2026-04-30 incident shape.                                                                                            |
@@ -20,6 +20,7 @@ Synthetic-DJ canary on AWS Lambda. Probes the WXYC user-facing API every five mi
 - Checks fail by **throwing**. The runner converts the throw into a `CheckOutcome` with `status: 'fail'` and the message. One throw never short-circuits the others (parallel `Promise.all` of independent try-catches).
 - `requiresAuth: true` checks downgrade to `skipped` (separate metric from `fail`) when no DJ credentials are configured. The alarm only fires on `fail`, so an operator who hasn't provisioned the DJ test account gets a noisy console but not a phone call.
 - Two credential paths: `CANARY_DJ_EMAIL` + `CANARY_DJ_PASSWORD` env vars (local + tests) or `CANARY_DJ_SECRET_ARN` pointing at a Secrets Manager secret with `{"email":"...","password":"..."}` (prod).
+- Retry policy: the canary does **not** retry the surfaces it measures. The lone carve-out is `signInDj` retrying once on 429 only — auth is a precondition shared by 4 of 6 checks, so a single 429 there cascades into 4 simultaneous fail outcomes plus a Lambda Errors alarm. The retry honors `Retry-After` (seconds form), capped at 5s to fit the Lambda budget. Token exchange is not retried.
 
 ## Adding a check
 
@@ -34,6 +35,7 @@ Synthetic-DJ canary on AWS Lambda. Probes the WXYC user-facing API every five mi
 - Each of the three 2026-04-30 incident shapes produces a `fail` outcome on the right check (catalog-search 503, semantic-index missing `results` envelope, LML proxy 504).
 - One failing check does not short-circuit the others.
 - Auth sign-in errors propagate as fail (not skip) on every DJ-auth check.
+- Sign-in 429 retries once (and only on 429) and recovers when the second attempt succeeds; both attempts failing or any non-429 fail the precondition without retrying.
 
 ## What this is not
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,4 +1,4 @@
-import { canaryFetch } from './client.js';
+import { canaryFetch, type FetchResult } from './client.js';
 import type { Check } from './types.js';
 
 /**
@@ -145,6 +145,20 @@ export const checks: readonly Check[] = [
 ];
 
 /**
+ * Parse a `Retry-After` header in seconds form (the date form is rare on
+ * better-auth and not handled). Returns milliseconds, or undefined when
+ * the header is missing/unparseable. Negative or non-finite values are
+ * treated as missing.
+ */
+function parseRetryAfterMs(result: FetchResult): number | undefined {
+  const raw = result.headers?.['retry-after'];
+  if (!raw) return undefined;
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
+  return Math.round(seconds * 1000);
+}
+
+/**
  * Sign in to better-auth as a DJ and return a JWT suitable for the
  * `Authorization: Bearer ...` header on Backend-Service routes. Throws on
  * any failure — caller is responsible for downgrading DJ-auth checks to
@@ -159,13 +173,30 @@ export const checks: readonly Check[] = [
  * CSRF guard rejects sign-in with `MISSING_OR_NULL_ORIGIN` when the header
  * is absent (curl, Lambda, anything non-browser). The value must be one of
  * the auth server's `BETTER_AUTH_TRUSTED_ORIGINS`.
+ *
+ * Retry carve-out: the canary deliberately does not retry the surfaces it
+ * measures (see `client.ts`). Sign-in is the exception, and only on 429.
+ * Auth is a precondition shared by 4 of 6 checks, so a single 429 here
+ * cascades into 4 simultaneous fail outcomes plus a Lambda Errors alarm —
+ * even when the surfaces being measured are healthy. One retry, only on
+ * 429, only on the sign-in step (token exchange does not retry). Honors
+ * `Retry-After` (seconds form) when present, capped to 5s so the Lambda
+ * still finishes inside its budget.
  */
 export async function signInDj(authUrl: string, email: string, password: string, originUrl: string): Promise<string> {
-  const signIn = await canaryFetch(`${authUrl}/sign-in/email`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Origin: originUrl },
-    body: JSON.stringify({ email, password }),
-  });
+  const postSignIn = (): Promise<FetchResult> =>
+    canaryFetch(`${authUrl}/sign-in/email`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: originUrl },
+      body: JSON.stringify({ email, password }),
+    });
+
+  let signIn = await postSignIn();
+  if (signIn.status === 429) {
+    const delayMs = Math.min(parseRetryAfterMs(signIn) ?? 2000, 5000);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    signIn = await postSignIn();
+  }
   if (!signIn.ok) {
     throw new Error(`auth sign-in failed with ${signIn.status}: ${signIn.rawText.slice(0, 200)}`);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,8 @@ export type FetchResult = {
   latencyMs: number;
   /** Raw text body. Useful for failure messages when JSON parse fails. */
   rawText: string;
+  /** Lowercased response headers. Used for things like `Retry-After`. */
+  headers: Record<string, string>;
 };
 
 export class CanaryFetchError extends Error {
@@ -52,12 +54,18 @@ export async function canaryFetch(
       }
     }
 
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+
     return {
       status: response.status,
       ok: response.ok,
       body,
       latencyMs,
       rawText,
+      headers,
     };
   } catch (err) {
     const latencyMs = Math.round(performance.now() - startedAt);

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -198,3 +198,162 @@ describe('runCanary — failure surfaces (regression coverage for the 2026-04-30
     expect(dj.message).toMatch(/token exchange/);
   });
 });
+
+/**
+ * Auth sign-in is the one place the canary retries (see signInDj). The
+ * carve-out exists because a single 429 on sign-in cascades into 4 fail
+ * outcomes plus a Lambda Errors alarm, even when the surfaces being
+ * measured are healthy. These tests pin the contract: retry on 429 only,
+ * once only, sign-in step only.
+ */
+describe('runCanary — sign-in 429 retry carve-out', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  /**
+   * Build a fetch mock where each URL pattern returns a queue of responses
+   * in order. After the queue is exhausted, the last response repeats —
+   * lets a test specify "fail once, then succeed" without enumerating
+   * every subsequent call.
+   */
+  function setUpSequentialFetchMock(
+    sequences: Record<string, { status: number; body: unknown; headers?: Record<string, string> }[]>
+  ) {
+    const calls: Record<string, number> = {};
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      for (const [pattern, queue] of Object.entries(sequences)) {
+        if (urlString.includes(pattern)) {
+          const idx = calls[pattern] ?? 0;
+          calls[pattern] = idx + 1;
+          const resp = queue[Math.min(idx, queue.length - 1)];
+          return new Response(typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body), {
+            status: resp.status,
+            headers: { 'Content-Type': 'application/json', ...(resp.headers ?? {}) },
+          });
+        }
+      }
+      return new Response(`unmatched mock for ${urlString}`, { status: 599 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return { fetchMock, calls };
+  }
+
+  it('retries sign-in once on 429 and proceeds when the second attempt succeeds', async () => {
+    vi.useFakeTimers();
+    const { fetchMock } = setUpSequentialFetchMock({
+      '/healthcheck': [{ status: 200, body: { ok: true } }],
+      '/proxy/library/search': [{ status: 200, body: proxyLibrarySearchResponse }],
+      '/graph/artists/search': [{ status: 200, body: { results: [{ id: 1 }] } }],
+      '/sign-in/email': [
+        { status: 429, body: { error: 'Too many requests, please try again later.' } },
+        { status: 200, body: { token: 'fake-session-token', user: { id: 'u1' } } },
+      ],
+      '/token': [{ status: 200, body: { token: 'fake-jwt' } }],
+      '/library/?artist_name=': [{ status: 200, body: stereolabSearchResults }],
+      '/flowsheet': [{ status: 200, body: [] }],
+      '/library/rotation': [{ status: 200, body: [] }],
+    });
+
+    const promise = runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    await vi.runAllTimersAsync();
+    const outcomes = await promise;
+
+    const byName = Object.fromEntries(outcomes.map((o) => [o.name, o]));
+    expect(byName['proxy-library-search'].status).toBe('pass');
+    expect(byName['dj-library-search'].status).toBe('pass');
+    expect(byName['dj-flowsheet-read'].status).toBe('pass');
+    expect(byName['dj-rotation'].status).toBe('pass');
+
+    const signInCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('/sign-in/email'));
+    expect(signInCalls).toHaveLength(2);
+  });
+
+  it('honors Retry-After (seconds) on 429, capped at 5s', async () => {
+    vi.useFakeTimers();
+    setUpSequentialFetchMock({
+      '/healthcheck': [{ status: 200, body: { ok: true } }],
+      '/proxy/library/search': [{ status: 200, body: proxyLibrarySearchResponse }],
+      '/graph/artists/search': [{ status: 200, body: { results: [{ id: 1 }] } }],
+      '/sign-in/email': [
+        // Server asks for 60s — far longer than the canary's budget. We cap at 5s.
+        { status: 429, body: { error: 'rate limited' }, headers: { 'Retry-After': '60' } },
+        { status: 200, body: { token: 'fake-session-token', user: { id: 'u1' } } },
+      ],
+      '/token': [{ status: 200, body: { token: 'fake-jwt' } }],
+      '/library/?artist_name=': [{ status: 200, body: stereolabSearchResults }],
+      '/flowsheet': [{ status: 200, body: [] }],
+      '/library/rotation': [{ status: 200, body: [] }],
+    });
+
+    const promise = runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    // Advance exactly 5s (the cap). If the cap weren't applied, the retry timer
+    // would still be pending and the sign-in promise wouldn't resolve.
+    await vi.advanceTimersByTimeAsync(5000);
+    const outcomes = await promise;
+
+    const dj = outcomes.find((o) => o.name === 'dj-library-search')!;
+    expect(dj.status).toBe('pass');
+  });
+
+  it('fails the precondition when both sign-in attempts return 429', async () => {
+    vi.useFakeTimers();
+    setUpSequentialFetchMock({
+      '/healthcheck': [{ status: 200, body: { ok: true } }],
+      '/proxy/library/search': [{ status: 200, body: proxyLibrarySearchResponse }],
+      '/graph/artists/search': [{ status: 200, body: { results: [{ id: 1 }] } }],
+      '/sign-in/email': [
+        { status: 429, body: { error: 'rate limited' } },
+        { status: 429, body: { error: 'rate limited' } },
+      ],
+    });
+
+    const promise = runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    await vi.runAllTimersAsync();
+    const outcomes = await promise;
+
+    const dj = outcomes.find((o) => o.name === 'dj-library-search')!;
+    expect(dj.status).toBe('fail');
+    expect(dj.message).toMatch(/auth precondition failed/);
+    expect(dj.message).toMatch(/429/);
+  });
+
+  it('does not retry on non-429 sign-in failures (e.g. 401)', async () => {
+    const { fetchMock } = setUpSequentialFetchMock({
+      '/healthcheck': [{ status: 200, body: { ok: true } }],
+      '/proxy/library/search': [{ status: 200, body: proxyLibrarySearchResponse }],
+      '/graph/artists/search': [{ status: 200, body: { results: [{ id: 1 }] } }],
+      '/sign-in/email': [{ status: 401, body: { error: 'invalid credentials' } }],
+    });
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'wrong' });
+
+    const dj = outcomes.find((o) => o.name === 'dj-library-search')!;
+    expect(dj.status).toBe('fail');
+    expect(dj.message).toMatch(/401/);
+
+    const signInCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('/sign-in/email'));
+    expect(signInCalls).toHaveLength(1);
+  });
+
+  it('does not retry the token-exchange step on 429', async () => {
+    const { fetchMock } = setUpSequentialFetchMock({
+      '/healthcheck': [{ status: 200, body: { ok: true } }],
+      '/proxy/library/search': [{ status: 200, body: proxyLibrarySearchResponse }],
+      '/graph/artists/search': [{ status: 200, body: { results: [{ id: 1 }] } }],
+      '/sign-in/email': [{ status: 200, body: { token: 'fake-session-token', user: { id: 'u1' } } }],
+      '/token': [{ status: 429, body: { error: 'rate limited' } }],
+    });
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+
+    const dj = outcomes.find((o) => o.name === 'dj-library-search')!;
+    expect(dj.status).toBe('fail');
+    expect(dj.message).toMatch(/token exchange/);
+
+    const tokenCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/token'));
+    expect(tokenCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #6

## Summary

- `signInDj` retries `/sign-in/email` once on 429, honoring `Retry-After` (seconds form) capped at 5s so the Lambda still fits its budget.
- Token exchange and the 6 measured-surface checks still do not retry — the existing no-retry principle for canary surfaces is preserved.
- Documented as a deliberate carve-out in `CLAUDE.md` and the `signInDj` docstring so a future reader doesn't undo it.

## Why

A single 429 on auth sign-in cascades into 4 simultaneous fail outcomes plus a Lambda Errors alarm, even when the four surfaces being measured are healthy. Observed 2026-05-07 16:51-16:52 UTC; alarm self-cleared at 16:58 UTC. See #6 for the incident detail.

## Root cause has been identified upstream

Post-filing, the structural cause was traced to a missing `app.set('trust proxy', true)` in Backend-Service's auth Express app — see [WXYC/Backend-Service#763](https://github.com/WXYC/Backend-Service/issues/763) / [PR #764](https://github.com/WXYC/Backend-Service/pull/764). Without that line, `express-rate-limit` falls back to the direct socket IP and the auth-mutation rate limit (10/15min) becomes a single global bucket shared across all clients. The 16:51 429 was that global bucket exhausting under normal traffic, not the canary itself being throttled.

This canary change is **defense-in-depth** and should still merge: even after per-IP rate-limiting is restored, transient 429s remain possible (sub-second bursts, future limit-tightening, etc.), and a single transient on a precondition shared by 4 of 6 checks is the wrong shape to cascade into 4 failures and a Lambda Errors alarm.

## Test plan

- [x] `npx prettier --check src test`
- [x] `npm run typecheck`
- [x] `npm test` — 13 passed (8 existing + 5 new):
  - 429 → success retry: all DJ-auth checks pass, sign-in called twice
  - `Retry-After: 60` honored but capped to 5s (advanceTimersByTimeAsync(5000) resolves the canary; if the cap weren't applied the test would hang)
  - 429 → 429: DJ-auth checks fail with `auth precondition failed` mentioning 429
  - 401 (non-429): no retry, sign-in called exactly once
  - Token-exchange 429: no retry, `/token` called exactly once
- [ ] Post-merge: confirm the next CloudWatch invocation passes; if better-auth ever 429s again briefly, the canary should produce a green run and not flip the alarm.

## Known limitation (out of scope)

The two consecutive 5-min runs both got 429, suggesting a rate-limit window of ≥60s. A 2-5s retry won't always escape that. This handles brief sub-second bursts and stops 4-way cascades; it does not make the canary survive a full 60s rate-limit window. The structural fix for that is WXYC/Backend-Service#763 / #764.