### PR TITLE
fix(template): set top-level Period on expression-only alarms

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -117,6 +117,10 @@ Resources:
     Properties:
       AlarmName: wxyc-canary-check-failure
       AlarmDescription: One or more WXYC canary checks have been failing.
+      # Period is required at the alarm level when every entry in Metrics
+      # uses Expression only (no MetricStat). PutMetricAlarm validation
+      # rejects the call with "Period must not be null" otherwise.
+      Period: 300
       Metrics:
         - Id: e1
           Expression: SUM(SEARCH('{WXYC/Canary,Check} MetricName="CheckFailure"', 'Sum', 300))
@@ -155,6 +159,7 @@ Resources:
         — Sentry-issues no longer carry 4xx after BS#691. Common causes:
         showMemberMiddleware 403 (DJ session lost show membership),
         validation 422, rate-limit 429.
+      Period: 300
       Metrics:
         - Id: e1
           Expression: SUM(SEARCH('{WXYC/BackendService} MetricName="MutationClientError"', 'Sum', 300))


### PR DESCRIPTION
## Why

The canary deploy workflow has been failing on \`SAM deploy\` since 2026-05-01 with:

\`\`\`
UPDATE_FAILED  AWS::CloudWatch::Alarm  CheckFailureAlarm
  "Period must not be null (Service: CloudWatch, Status Code: 400)"
\`\`\`

Root cause: \`CheckFailureAlarm\` and \`MutationClientErrorSurgeAlarm\` both use \`Metrics:\` with Expression-only entries (no MetricStat). The CloudWatch \`PutMetricAlarm\` API requires top-level \`Period\` on the alarm when every Metrics query uses Expression alone — without it, validation fails. The \`SUM(SEARCH(..., 'Sum', 300))\` expression's third argument is the metric resolution, not the alarm period.

This is why the deployed stack still has the **old** simple-form CheckFailureAlarm: every attempt to roll forward to the expression form has rolled back. Once this lands, the canary will both pick up the dimension-aware alarm (the #2/#3 fix) and the Node 24 runtime change from #9.

## What

Add \`Period: 300\` (5 minutes, matching EvaluationPeriods cadence) at the alarm level on both:
- \`CheckFailureAlarm\`
- \`MutationClientErrorSurgeAlarm\`

Inline comment on CheckFailureAlarm documents the constraint so the next person doesn't hit the same trap.

## Test plan

- [x] Local: \`npm run typecheck\` clean, 13/13 tests pass, \`npm run format:check\` clean
- [ ] Deploy workflow goes green; stack \`UPDATE_COMPLETE\`
- [ ] \`aws cloudwatch describe-alarms --alarm-names wxyc-canary-check-failure wxyc-canary-mutation-4xx-surge\` returns both alarms in \`OK\` (not \`INSUFFICIENT_DATA\`) within 15 min
- [ ] \`aws lambda get-function --function-name wxyc-canary\` returns \`Runtime: nodejs24.x\`