### PR TITLE
fix(template): move Period inside MetricDataQuery, not alarm level

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -117,14 +117,15 @@ Resources:
     Properties:
       AlarmName: wxyc-canary-check-failure
       AlarmDescription: One or more WXYC canary checks have been failing.
-      # Period is required at the alarm level when every entry in Metrics
-      # uses Expression only (no MetricStat). PutMetricAlarm validation
-      # rejects the call with "Period must not be null" otherwise.
-      Period: 300
+      # MetricDataQuery.Period is required when the entry uses Expression
+      # only (no MetricStat). PutMetricAlarm rejects the call with
+      # "Period must not be null" otherwise. The SEARCH function's third
+      # argument is the metric data resolution, not the alarm period.
       Metrics:
         - Id: e1
           Expression: SUM(SEARCH('{WXYC/Canary,Check} MetricName="CheckFailure"', 'Sum', 300))
           Label: TotalCheckFailures
+          Period: 300
           ReturnData: true
       EvaluationPeriods: 3
       DatapointsToAlarm: 2
@@ -159,11 +160,11 @@ Resources:
         — Sentry-issues no longer carry 4xx after BS#691. Common causes:
         showMemberMiddleware 403 (DJ session lost show membership),
         validation 422, rate-limit 429.
-      Period: 300
       Metrics:
         - Id: e1
           Expression: SUM(SEARCH('{WXYC/BackendService} MetricName="MutationClientError"', 'Sum', 300))
           Label: TotalMutationClientErrors
+          Period: 300
           ReturnData: true
       EvaluationPeriods: 2
       DatapointsToAlarm: 2


### PR DESCRIPTION
## Why

The previous fix (8b261ca) put \`Period\` at the alarm level, but for \`AWS::CloudWatch::Alarm\` resources using \`Metrics\` with Expression-only entries, \`Period\` belongs **inside each MetricDataQuery** — not at the alarm level. CloudFormation/PutMetricAlarm rejected the previous version with the same \"Period must not be null\" error (run #25744038731).

## What

Moves \`Period: 300\` from the alarm Properties block into each MetricDataQuery in the \`Metrics\` array, for both \`CheckFailureAlarm\` and \`MutationClientErrorSurgeAlarm\`. Inline comment updated to describe the correct placement.

## Test plan

- [x] Local: \`npm run format:check\` clean
- [ ] Deploy workflow goes green; stack \`UPDATE_COMPLETE\`
- [ ] \`aws lambda get-function --function-name wxyc-canary\` returns \`Runtime: nodejs24.x\`
- [ ] \`aws cloudwatch describe-alarms --alarm-names wxyc-canary-check-failure wxyc-canary-mutation-4xx-surge\` shows both in \`OK\` within 15 min