### PR TITLE
Add PR-time CI workflow to gate merges on quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run format:check
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary

- New `.github/workflows/ci.yml` that fires on `pull_request: branches: [main]` and runs `npm run typecheck`, `npm run format:check`, `npm test`, and `npm run build`.
- Implements Shape A from #19: cleanest separation between validate-on-PR and deploy-on-main.
- `deploy.yml` is untouched; its post-merge `test` job stays as defense-in-depth (the issue notes either is reasonable, and "stay focused" suggests not folding in an optional cleanup).
- Inherits Node 24 and `@v6` action pins from `deploy.yml`. No new version pins, no matrix, no required-status-check rules (those are branch-protection settings, owned separately).

Closes #19.

## Test plan

- [x] Local: `npm run typecheck`, `npm run format:check`, `npm test`, `npm run build` all pass.
- [ ] PR check runs and reports a green `ci` status on this PR (validates the workflow itself triggers).
- [ ] Future verification per #19 acceptance: open a deliberate red PR (e.g., a `format:check` violation) and confirm `statusCheckRollup` reports failure; revert and confirm it flips green.