### PR TITLE
Bump aws-actions/setup-sam to v3 and configure-aws-credentials to v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           node-version: '24'
           cache: npm
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

- Bump `aws-actions/setup-sam@v2` → `@v3` and `aws-actions/configure-aws-credentials@v4` → `@v6` in `.github/workflows/deploy.yml` so the actions run on Node 24 before GitHub's 2026-06-02 auto-coercion of Node 20 actions.
- `setup-sam@v3` (released 2026-05-01) is a pure Node 16→24 runtime bump per its release notes.
- `configure-aws-credentials@v6` (released 2026-02-04, latest v6.1.1 on 2026-05-05) bumps the action to Node 24; the only other breaking change in the v5/v6 line is stricter boolean-input parsing, which doesn't apply here — we only pass string secrets and the region.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 17 tests pass, including the `template.yaml ↔ publishMetrics contract` regression
- [ ] Post-merge deploy run succeeds and the Node 20 deprecation annotation is gone
- [ ] Both alarms (`wxyc-canary-check-failure`, `wxyc-canary-lambda-errors`) stay `OK` through the deploy

Closes #21