### PR TITLE
Add dj-rotation-picker probe to catch BS#994 / BS#1030 cascade class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ The canary exists because three production incidents on 2026-04-30 (catalog-sear
 
 ## What it checks
 
-| Check                   | Endpoint                                                                | Auth             | What it would have caught                                        |
-| ----------------------- | ----------------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------- |
-| `backend-healthcheck`   | `GET /healthcheck`                                                      | none             | Process-level outage on Backend-Service                          |
-| `proxy-library-search`  | `GET /proxy/library/search?artist=Stereolab&limit=5`                    | anonymous device | LML degradation, BS proxy regressions                            |
-| `semantic-index-search` | `GET https://explore.wxyc.org/graph/artists/search?q=Stereolab&limit=1` | none             | semantic-index 5xx; missing `results` envelope                   |
-| `dj-library-search`     | `GET /library/?artist_name=Stereolab&n=5`                               | DJ JWT           | The 2026-04-30 catalog-search 503 incident, exactly              |
-| `dj-flowsheet-read`     | `GET /v2/flowsheet?n=5`                                                 | DJ JWT           | V2 flowsheet read regressions                                    |
-| `dj-rotation`           | `GET /library/rotation`                                                 | DJ JWT           | Rotation endpoint 5xx, fully empty rotation                      |
-| `enrichment-quality`    | insert sentinel → poll for enrichment → delete                          | DJ JWT (write)   | The 2026-05-13 LML cascade regression (null-metadata on inserts) |
+| Check                   | Endpoint                                                                | Auth             | What it would have caught                                                                                               |
+| ----------------------- | ----------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `backend-healthcheck`   | `GET /healthcheck`                                                      | none             | Process-level outage on Backend-Service                                                                                 |
+| `proxy-library-search`  | `GET /proxy/library/search?artist=Stereolab&limit=5`                    | anonymous device | LML degradation, BS proxy regressions                                                                                   |
+| `semantic-index-search` | `GET https://explore.wxyc.org/graph/artists/search?q=Stereolab&limit=1` | none             | semantic-index 5xx; missing `results` envelope                                                                          |
+| `dj-library-search`     | `GET /library/?artist_name=Stereolab&n=5`                               | DJ JWT           | The 2026-04-30 catalog-search 503 incident, exactly                                                                     |
+| `dj-flowsheet-read`     | `GET /v2/flowsheet?n=5`                                                 | DJ JWT           | V2 flowsheet read regressions                                                                                           |
+| `dj-rotation`           | `GET /library/rotation`                                                 | DJ JWT           | Rotation endpoint 5xx, fully empty rotation                                                                             |
+| `dj-rotation-picker`    | `GET /library/rotation/{id}/tracks` (id discovered from list)           | DJ JWT           | The BS#994 / BS#1030 cascade-to-502 class; LML-cascade timeouts on the picker that previously surfaced via on-air Slack |
+| `enrichment-quality`    | insert sentinel → poll for enrichment → delete                          | DJ JWT (write)   | The 2026-05-13 LML cascade regression (null-metadata on inserts)                                                        |
 
 DJ-auth checks downgrade to `skipped` (a distinct CloudWatch metric, not `failed`) when no DJ credentials are configured, so the alarm doesn't fire on operator-caused gaps. The `enrichment-quality` write canary additionally requires `CANARY_ENABLE_WRITE_PROBE=true` and skips when another DJ is on-air — the canary deliberately doesn't inject sentinel rows into a real DJ's flowsheet.
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,6 +1,6 @@
 import { canaryFetch, type FetchResult } from './client.js';
 import { runEnrichmentCheck } from './enrichment-check.js';
-import type { Check } from './types.js';
+import type { Check, CheckResult } from './types.js';
 
 /**
  * The canonical artist used for read-side probes. Stereolab has been on
@@ -137,6 +137,62 @@ const djRotation: Check = {
 };
 
 /**
+ * DJ-authenticated: the dj-site rotation picker. On selecting a rotation
+ * row in the flowsheet entry UI, dj-site calls `GET /library/rotation/{id}/tracks`
+ * to populate a track dropdown. The endpoint was the user-visible failure
+ * surface of BS#994 / BS#1030: when LML was under cascade load, individual
+ * release-id lookups timed out, the controller short-circuited to 502, and
+ * on-air DJs saw "Loading tracks..." that never resolved. BS#1029 made 21%
+ * of active rotation rows JOIN-resolvable (no LML call needed), but the
+ * remaining ~79% still depend on the runtime cascade — so this probe both
+ * pins the JOIN path stays healthy and acts as a leading indicator for the
+ * cascade-class regression that surfaced today via on-air Slack messages
+ * rather than any monitor.
+ *
+ * Self-healing target: rather than hardcode a rotation id (which would
+ * break when that row gets killed), the probe discovers a candidate from
+ * the rotation list itself. Any 2xx + array response is a pass — the body
+ * is allowed to be empty because a real release may have zero indexed
+ * tracks (e.g., never cross-referenced with Discogs). The 8 s per-fetch
+ * timeout in `canaryFetch` is the regression signal: BS#994's cascade was
+ * a 30 s timeout chain → 502, so anything that gets within shouting
+ * distance of the budget produces a `fail`.
+ */
+const djRotationPicker: Check = {
+  name: 'dj-rotation-picker',
+  description: 'GET /library/rotation/{id}/tracks as DJ — catches BS#994 / BS#1030 cascade-to-502 class',
+  requiresAuth: true,
+  run: async (ctx): Promise<CheckResult | void> => {
+    if (!ctx.djBearerToken) throw new Error('DJ bearer token missing');
+    const list = await canaryFetch(`${ctx.backendUrl}/library/rotation`, {
+      headers: { Authorization: `Bearer ${ctx.djBearerToken}` },
+    });
+    if (!list.ok) {
+      throw new Error(`rotation list precondition: expected 2xx, got ${list.status}: ${list.rawText.slice(0, 200)}`);
+    }
+    if (!Array.isArray(list.body)) {
+      throw new Error(`rotation list precondition: expected array body, got ${typeof list.body}`);
+    }
+    const first = list.body[0] as { id?: number } | undefined;
+    if (!first || typeof first.id !== 'number') {
+      // The dj-rotation check already alerts on an empty rotation; this probe
+      // intentionally degrades to skipped so the picker signal doesn't
+      // duplicate that one. With rotation empty there's nothing to probe.
+      return { skipped: true, skipReason: 'rotation list is empty — no probe target available' };
+    }
+    const tracks = await canaryFetch(`${ctx.backendUrl}/library/rotation/${first.id}/tracks`, {
+      headers: { Authorization: `Bearer ${ctx.djBearerToken}` },
+    });
+    if (!tracks.ok) {
+      throw new Error(`expected 2xx, got ${tracks.status}: ${tracks.rawText.slice(0, 200)}`);
+    }
+    if (!Array.isArray(tracks.body)) {
+      throw new Error(`expected array body, got ${typeof tracks.body}: ${tracks.rawText.slice(0, 200)}`);
+    }
+  },
+};
+
+/**
  * Write canary (v1). Inserts a sentinel flowsheet row, polls until LML
  * enrichment populates `youtube_music_url`, deletes the row, ends the
  * canary's show. Returns an `EnrichmentLagSeconds` metric the runner
@@ -167,6 +223,7 @@ export const checks: readonly Check[] = [
   djLibrarySearch,
   djFlowsheetRead,
   djRotation,
+  djRotationPicker,
   enrichmentQuality,
 ];
 

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -83,10 +83,10 @@ describe('runCanary — anonymous-only configuration', () => {
     vi.unstubAllGlobals();
   });
 
-  it('passes the 2 truly-anonymous checks and skips the 5 auth checks when no credentials are configured', async () => {
+  it('passes the 2 truly-anonymous checks and skips the 6 auth checks when no credentials are configured', async () => {
     const outcomes = await runCanary(baseConfig);
 
-    expect(outcomes).toHaveLength(7);
+    expect(outcomes).toHaveLength(8);
     const byName = Object.fromEntries(outcomes.map((o) => [o.name, o]));
     expect(byName['backend-healthcheck'].status).toBe('pass');
     expect(byName['semantic-index-search'].status).toBe('pass');
@@ -94,6 +94,7 @@ describe('runCanary — anonymous-only configuration', () => {
     expect(byName['dj-library-search'].status).toBe('skipped');
     expect(byName['dj-flowsheet-read'].status).toBe('skipped');
     expect(byName['dj-rotation'].status).toBe('skipped');
+    expect(byName['dj-rotation-picker'].status).toBe('skipped');
     expect(byName['enrichment-quality'].status).toBe('skipped');
   });
 });
@@ -176,6 +177,72 @@ describe('runCanary — failure surfaces (regression coverage for the 2026-04-30
 
     expect(dj.status).toBe('fail');
     expect(dj.message).toMatch(/at least 1 hit/);
+  });
+
+  // Regression coverage for the BS#994 / BS#1029 / BS#1030 cluster. Without
+  // this check, the rotation-picker endpoint was only exercised when an
+  // on-air DJ tried to log a rotation track — outages surfaced as a
+  // "Loading tracks..." spinner that a DJ Slacked in, not as a metric.
+  // BS#1029 made 21% of active rotation rows JOIN-resolvable; the picker
+  // probe pins that the endpoint stays 2xx + array-shaped, so a future
+  // regression of either the JOIN path or the runtime cascade pages within
+  // ~5 min instead of waiting for someone to spot the spinner.
+  it('catches the rotation picker returning 502 (BS#1030 cascade-to-502 regression class)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      '/sign-in/email': { status: 200, body: { token: 'fake-session-token', user: { id: 'u1' } } },
+      '/token': { status: 200, body: { token: 'fake-jwt' } },
+      '/library/?artist_name=': { status: 200, body: stereolabSearchResults },
+      '/flowsheet': { status: 200, body: [] },
+      '/library/rotation/21522/tracks': { status: 502, body: { message: 'lookupReleaseId: LML cascade timed out' } },
+      '/library/rotation': { status: 200, body: [{ id: 21522 }] },
+    });
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    const picker = outcomes.find((o) => o.name === 'dj-rotation-picker')!;
+
+    expect(picker.status).toBe('fail');
+    expect(picker.message).toMatch(/502/);
+  });
+
+  it('passes the picker probe when the rotation list yields an id and /tracks returns an array', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      '/sign-in/email': { status: 200, body: { token: 'fake-session-token', user: { id: 'u1' } } },
+      '/token': { status: 200, body: { token: 'fake-jwt' } },
+      '/library/?artist_name=': { status: 200, body: stereolabSearchResults },
+      '/flowsheet': { status: 200, body: [] },
+      '/library/rotation/4242/tracks': { status: 200, body: [{ id: 1, title: 'la paradoja' }] },
+      '/library/rotation': { status: 200, body: [{ id: 4242 }] },
+    });
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    const picker = outcomes.find((o) => o.name === 'dj-rotation-picker')!;
+
+    expect(picker.status).toBe('pass');
+  });
+
+  it('skips the picker probe when the rotation list is empty (cannot synthesize a probe target)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      '/sign-in/email': { status: 200, body: { token: 'fake-session-token', user: { id: 'u1' } } },
+      '/token': { status: 200, body: { token: 'fake-jwt' } },
+      '/library/?artist_name=': { status: 200, body: stereolabSearchResults },
+      '/flowsheet': { status: 200, body: [] },
+      '/library/rotation': { status: 200, body: [] },
+    });
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    const picker = outcomes.find((o) => o.name === 'dj-rotation-picker')!;
+
+    expect(picker.status).toBe('skipped');
+    expect(picker.message).toMatch(/rotation/i);
   });
 
   it('does not short-circuit other checks when one fails', async () => {
@@ -444,9 +511,9 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     const dimensioned = checkFailureData.filter((d) => d.Dimensions && d.Dimensions.length > 0);
     const dimensionless = checkFailureData.filter((d) => !d.Dimensions || d.Dimensions.length === 0);
 
-    // Seven checks, each contributes one dimensioned and one dimensionless datapoint.
-    expect(dimensioned).toHaveLength(7);
-    expect(dimensionless).toHaveLength(7);
+    // Eight checks, each contributes one dimensioned and one dimensionless datapoint.
+    expect(dimensioned).toHaveLength(8);
+    expect(dimensionless).toHaveLength(8);
     // Without an inducer, every value is 0 (passes + skips).
     expect(dimensioned.every((d) => d.Value === 0)).toBe(true);
     expect(dimensionless.every((d) => d.Value === 0)).toBe(true);
@@ -478,7 +545,7 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     // isn't enough — `Statistic: Maximum` on the alarm needs at least one
     // `1` in the window, so this asserts the count of 1s explicitly.
     expect(dimensionless.filter((d) => d.Value === 1)).toHaveLength(1);
-    expect(dimensionless.filter((d) => d.Value === 0)).toHaveLength(6);
+    expect(dimensionless.filter((d) => d.Value === 0)).toHaveLength(7);
   });
 
   // `CheckSkipped` and `CheckLatency` are dashboard data, not alarm inputs.
@@ -499,8 +566,8 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     expect(metricData.filter((d) => d.MetricName === 'CheckSkipped' && isDimensionless(d))).toHaveLength(0);
     expect(metricData.filter((d) => d.MetricName === 'CheckLatency' && isDimensionless(d))).toHaveLength(0);
     // Sanity: the dimensioned series for each is present (one per check).
-    expect(metricData.filter((d) => d.MetricName === 'CheckSkipped')).toHaveLength(7);
-    expect(metricData.filter((d) => d.MetricName === 'CheckLatency')).toHaveLength(7);
+    expect(metricData.filter((d) => d.MetricName === 'CheckSkipped')).toHaveLength(8);
+    expect(metricData.filter((d) => d.MetricName === 'CheckLatency')).toHaveLength(8);
   });
 });
 


### PR DESCRIPTION
Closes #27.

## Summary

- New \`dj-rotation-picker\` check: signs in as DJ, discovers a rotation row id from \`GET /library/rotation\`, then GETs \`/library/rotation/{id}/tracks\` and asserts 2xx + array body.
- Self-healing — no hardcoded id. Empty rotation → \`skipped\` so the signal doesn't duplicate \`dj-rotation\`'s empty-rotation alarm.
- The 8 s per-fetch budget in \`canaryFetch\` is the regression signal: BS#994's cascade was a 30 s timeout chain → 502, so anything within shouting distance fails the probe.
- No template changes. The existing \`wxyc-canary-check-failure\` alarm aggregates the new \`CheckFailure\` series automatically via emit-twice (dimensioned + dimensionless).

## Why this check

The dj-site rotation picker (\`GET /library/rotation/{id}/tracks\`) was the user-visible failure surface of BS#994 (May 21) and re-surfaced via on-air Slack today (BS#1030, May 28). BS#1029 made 21% of active rotation rows JOIN-resolvable, but the remaining ~79% still depend on the runtime cascade — so this probe both pins the JOIN path and acts as a leading indicator for the cascade re-emerging on the unresolved rows.

## Test plan

- [x] \`npm test\` — 36 tests pass (+3 picker probe cases; +5 count-bump deltas on the existing dimensioned/dimensionless contract tests).
- [x] \`npm run typecheck\` clean.
- [x] \`npm run format:check\` clean.
- [x] \`npm run build\` succeeds.
- [x] \`sam validate --lint\` succeeds.
- [ ] Post-deploy: verify \`CheckFailure.Check=dj-rotation-picker\` series shows up in CloudWatch within 10 minutes; first invocation should pass against prod (rotation is non-empty + picker endpoint healthy).

## Related

- WXYC/Backend-Service#994, #1029, #1030, #1195
- Canary sibling: #26 (GitHub-issue reporter, just merged)