### PR TITLE
Add lml-auth check (BS#1094 layer 1 — LML_API_KEY rotation drift)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,5 +57,7 @@ jobs:
               BackendUrl=${{ vars.BACKEND_URL || 'https://api.wxyc.org' }} \
               AuthUrl=${{ vars.AUTH_URL || 'https://api.wxyc.org/auth' }} \
               SemanticIndexUrl=${{ vars.SEMANTIC_INDEX_URL || 'https://explore.wxyc.org' }} \
+              LmlUrl=${{ vars.LML_URL || 'https://library-metadata-lookup-production.up.railway.app' }} \
+              LmlApiKeySecretArn=${{ secrets.LML_API_KEY_SECRET_ARN }} \
               DjCredentialsSecretArn=${{ secrets.DJ_CREDENTIALS_SECRET_ARN }} \
               AlertEmail=${{ vars.ALERT_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The canary exists because three production incidents on 2026-04-30 (catalog-sear
 | `dj-flowsheet-read`     | `GET /v2/flowsheet?n=5`                                                 | DJ JWT           | V2 flowsheet read regressions                                                                                           |
 | `dj-rotation`           | `GET /library/rotation`                                                 | DJ JWT           | Rotation endpoint 5xx, fully empty rotation                                                                             |
 | `dj-rotation-picker`    | `GET /library/rotation/{id}/tracks` (id discovered from list)           | DJ JWT           | The BS#994 / BS#1030 cascade-to-502 class; LML-cascade timeouts on the picker that previously surfaced via on-air Slack |
+| `lml-auth`              | `POST /api/v1/lookup` directly to LML with `LML_API_KEY`                | LML bearer       | BS#1094 `LML_API_KEY` rotation drift — silent BS backfill stall when the bearer is rolled without coordinated rollout   |
 | `enrichment-quality`    | insert sentinel → poll for enrichment → delete                          | DJ JWT (write)   | The 2026-05-13 LML cascade regression (null-metadata on inserts)                                                        |
 
-DJ-auth checks downgrade to `skipped` (a distinct CloudWatch metric, not `failed`) when no DJ credentials are configured, so the alarm doesn't fire on operator-caused gaps. The `enrichment-quality` write canary additionally requires `CANARY_ENABLE_WRITE_PROBE=true` and skips when another DJ is on-air — the canary deliberately doesn't inject sentinel rows into a real DJ's flowsheet.
+DJ-auth checks downgrade to `skipped` (a distinct CloudWatch metric, not `failed`) when no DJ credentials are configured, so the alarm doesn't fire on operator-caused gaps. The `lml-auth` check follows the same shape: it skips when no `LML_API_KEY` is configured. The `enrichment-quality` write canary additionally requires `CANARY_ENABLE_WRITE_PROBE=true` and skips when another DJ is on-air — the canary deliberately doesn't inject sentinel rows into a real DJ's flowsheet.
 
 ## Architecture
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -193,6 +193,60 @@ const djRotationPicker: Check = {
 };
 
 /**
+ * Direct POST to LML's `/api/v1/lookup` with the production
+ * `LML_API_KEY` bearer. Catches `LML_API_KEY` rotation drift in
+ * isolation from the BS proxy path: `proxy-library-search` exercises
+ * BS→LML through a DJ JWT, so a missing bearer there fails as "BS lost
+ * the header" rather than "the LML bearer is stale". This check removes
+ * BS from the loop entirely. Layer-1 mitigation for BS#1094 — the
+ * silent backfill stall the org saw the last time the bearer was
+ * rotated without a coordinated rollout (Sentry per row, no aggregated
+ * alarm, predicate didn't know about auth).
+ *
+ * Skips when no LML bearer is configured (operator gap, mirrors the
+ * DJ-credentials pattern). A 401/403 is the rotation-drift signal; a
+ * 5xx points at LML itself, not the auth chain. The probe payload uses
+ * a canonical WXYC-representative fixture (Juana Molina / DOGA / la
+ * paradoja) from `wxyc-shared`'s example data so the request body is
+ * indistinguishable from a real DJ lookup. We don't assert on the
+ * `results` shape — that's `proxy-library-search`'s job; this check
+ * scopes to "the bearer is accepted and LML answered 2xx".
+ */
+const lmlAuth: Check = {
+  name: 'lml-auth',
+  description: 'POST /api/v1/lookup directly to LML with LML_API_KEY — catches BS#1094 bearer rotation drift',
+  requiresAuth: false,
+  run: async (ctx): Promise<CheckResult | void> => {
+    if (!ctx.lmlApiKey) {
+      return { skipped: true, skipReason: 'no LML_API_KEY configured' };
+    }
+    const body = JSON.stringify({
+      artist: 'Juana Molina',
+      album: 'DOGA',
+      song: 'la paradoja',
+      raw_message: 'Juana Molina - la paradoja (DOGA)',
+    });
+    const r = await canaryFetch(`${ctx.lmlUrl}/api/v1/lookup`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${ctx.lmlApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+    if (r.status === 401 || r.status === 403) {
+      // Distinct message so the operator sees "rotation drift" not "LML
+      // down". The bearer is rolled across BS + rom + tubafrenzy + canary;
+      // a 401/403 here means at least one of those is wedged the same way.
+      throw new Error(
+        `LML rejected bearer with ${r.status} (likely LML_API_KEY rotation drift): ${r.rawText.slice(0, 200)}`
+      );
+    }
+    if (!r.ok) throw new Error(`expected 2xx, got ${r.status}: ${r.rawText.slice(0, 200)}`);
+  },
+};
+
+/**
  * Write canary (v1). Inserts a sentinel flowsheet row, polls until LML
  * enrichment populates `youtube_music_url`, deletes the row, ends the
  * canary's show. Returns an `EnrichmentLagSeconds` metric the runner
@@ -224,6 +278,7 @@ export const checks: readonly Check[] = [
   djFlowsheetRead,
   djRotation,
   djRotationPicker,
+  lmlAuth,
   enrichmentQuality,
 ];
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -19,6 +19,8 @@ function loadConfigFromEnv(): CanaryConfig {
     backendUrl: required('CANARY_BACKEND_URL'),
     authUrl: required('CANARY_AUTH_URL'),
     semanticIndexUrl: required('CANARY_SEMANTIC_INDEX_URL'),
+    lmlUrl: process.env.CANARY_LML_URL ?? 'https://library-metadata-lookup-production.up.railway.app',
+    lmlApiKey: process.env.CANARY_LML_API_KEY,
     originUrl: process.env.CANARY_ORIGIN_URL ?? 'https://dj.wxyc.org',
     djEmail: process.env.CANARY_DJ_EMAIL,
     djPassword: process.env.CANARY_DJ_PASSWORD,
@@ -63,6 +65,29 @@ async function resolveDjCredentials(config: CanaryConfig): Promise<{ email: stri
 }
 
 /**
+ * Resolve the LML bearer from one of two sources, in order:
+ *   1. `CANARY_LML_API_KEY` env var (local + tests + simple prod).
+ *   2. `CANARY_LML_API_KEY_SECRET_ARN` pointing at a Secrets Manager
+ *      secret whose `SecretString` is the bearer itself (plain string,
+ *      not JSON — Railway-style secret-store convention so the bearer
+ *      rotates in one place across BS + rom + tubafrenzy + canary).
+ * Returns undefined when neither is configured — the `lml-auth` check
+ * then downgrades to skipped (operator gap, not regression).
+ */
+async function resolveLmlApiKey(config: CanaryConfig): Promise<string | undefined> {
+  if (config.lmlApiKey) return config.lmlApiKey;
+  const secretArn = process.env.CANARY_LML_API_KEY_SECRET_ARN;
+  if (!secretArn) return undefined;
+
+  const sm = new SecretsManagerClient({ region: config.awsRegion ?? 'us-east-1' });
+  const result = await sm.send(new GetSecretValueCommand({ SecretId: secretArn }));
+  if (!result.SecretString) {
+    throw new Error(`secret ${secretArn} has no SecretString`);
+  }
+  return result.SecretString;
+}
+
+/**
  * Run every check, regardless of individual failures. Returns one outcome
  * per check. DJ-auth checks downgrade to 'skipped' when no DJ credentials
  * are configured — distinct from 'fail' so the alarm only fires on real
@@ -76,6 +101,18 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
     djCreds = await resolveDjCredentials(config);
   } catch (err) {
     djAuthError = `credential resolution failed: ${(err as Error).message}`;
+  }
+
+  // LML bearer resolution is independent of DJ auth: the lml-auth check
+  // skips on absence, fails on resolve errors (Secrets Manager outages
+  // are real, distinct signals — collapsing them into "skipped" would
+  // hide an IAM/SM regression).
+  let lmlApiKey: string | undefined;
+  let lmlAuthError: string | undefined;
+  try {
+    lmlApiKey = await resolveLmlApiKey(config);
+  } catch (err) {
+    lmlAuthError = `LML bearer resolution failed: ${(err as Error).message}`;
   }
 
   let djBearerToken: string | undefined;
@@ -103,6 +140,8 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
     backendUrl: config.backendUrl,
     authUrl: config.authUrl,
     semanticIndexUrl: config.semanticIndexUrl,
+    lmlUrl: config.lmlUrl ?? 'https://library-metadata-lookup-production.up.railway.app',
+    lmlApiKey,
     djBearerToken,
     djUserId,
     enrichmentPollTimeoutMs: config.enrichmentPollTimeoutMs ?? DEFAULT_ENRICHMENT_POLL_TIMEOUT_MS,
@@ -116,6 +155,12 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
       }
       if (check.requiresAuth && djAuthError) {
         return { name: check.name, status: 'fail', latencyMs: 0, message: `auth precondition failed: ${djAuthError}` };
+      }
+      // The lml-auth check fails (not skips) when bearer resolution
+      // errored — a Secrets Manager outage / IAM regression is a real
+      // signal that warrants paging, not a silent skip.
+      if (check.name === 'lml-auth' && lmlAuthError) {
+        return { name: check.name, status: 'fail', latencyMs: 0, message: lmlAuthError };
       }
       if (check.writes && !config.enableWriteProbe) {
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,22 @@ export type CheckContext = {
   backendUrl: string;
   authUrl: string;
   semanticIndexUrl: string;
+  /**
+   * library-metadata-lookup base URL (no trailing slash). The `lml-auth`
+   * check POSTs directly here to detect LML_API_KEY rotation drift in
+   * isolation from the BS proxy path that `proxy-library-search` also
+   * exercises.
+   */
+  lmlUrl: string;
+  /**
+   * Production LML bearer (the shared service-to-service secret that BS,
+   * rom, and tubafrenzy also send). Undefined when neither the
+   * `CANARY_LML_API_KEY` env var nor a `CANARY_LML_API_KEY_SECRET_ARN`
+   * Secrets Manager secret is configured — the `lml-auth` check then
+   * downgrades to skipped (operator-configuration gap, not regression —
+   * same pattern as the DJ credentials).
+   */
+  lmlApiKey: string | undefined;
   /** Bearer token if the canary has logged in as a DJ; undefined for anonymous-only runs. */
   djBearerToken: string | undefined;
   /**
@@ -87,6 +103,18 @@ export type CanaryConfig = {
   backendUrl: string;
   authUrl: string;
   semanticIndexUrl: string;
+  /**
+   * library-metadata-lookup base URL (no trailing slash). Defaults to
+   * `https://library-metadata-lookup-production.up.railway.app` in the
+   * handler when unset.
+   */
+  lmlUrl?: string;
+  /**
+   * Production LML bearer (shared with BS, rom, tubafrenzy). When unset,
+   * the `lml-auth` check downgrades to skipped — same operator-gap
+   * semantics as the DJ-credentials path.
+   */
+  lmlApiKey?: string;
   /**
    * Sent as `Origin:` on auth calls (sign-in, token exchange). Must match one
    * of the auth server's `BETTER_AUTH_TRUSTED_ORIGINS` or sign-in returns

--- a/template.yaml
+++ b/template.yaml
@@ -18,6 +18,23 @@ Parameters:
     Type: String
     Default: https://explore.wxyc.org
     Description: semantic-index base URL.
+  LmlUrl:
+    Type: String
+    Default: https://library-metadata-lookup-production.up.railway.app
+    Description: >
+      library-metadata-lookup base URL. The `lml-auth` check POSTs
+      directly to `${LmlUrl}/api/v1/lookup` with `LML_API_KEY` to detect
+      bearer rotation drift in isolation from the BS proxy path.
+  LmlApiKeySecretArn:
+    Type: String
+    Default: ''
+    Description: >
+      Optional ARN of a Secrets Manager secret whose `SecretString` is
+      the production LML bearer (plain string, not JSON — matches
+      Railway's one-secret-one-value convention so the bearer rotates
+      in one place across BS + rom + tubafrenzy + canary). When empty,
+      the `lml-auth` check downgrades to skipped (operator gap, not
+      regression — same shape as the DJ-credentials path).
   DjCredentialsSecretArn:
     Type: String
     Default: ''
@@ -77,6 +94,7 @@ Parameters:
 
 Conditions:
   HasDjCredentials: !Not [!Equals [!Ref DjCredentialsSecretArn, '']]
+  HasLmlApiKey: !Not [!Equals [!Ref LmlApiKeySecretArn, '']]
   HasAlertEmail: !Not [!Equals [!Ref AlertEmail, '']]
   HasGitHubReporter: !And
     - !Not [!Equals [!Ref GitHubTokenSsmParamName, '']]
@@ -100,6 +118,8 @@ Resources:
           CANARY_BACKEND_URL: !Ref BackendUrl
           CANARY_AUTH_URL: !Ref AuthUrl
           CANARY_SEMANTIC_INDEX_URL: !Ref SemanticIndexUrl
+          CANARY_LML_URL: !Ref LmlUrl
+          CANARY_LML_API_KEY_SECRET_ARN: !If [HasLmlApiKey, !Ref LmlApiKeySecretArn, '']
           CANARY_DJ_SECRET_ARN: !If [HasDjCredentials, !Ref DjCredentialsSecretArn, '']
           CANARY_ENABLE_WRITE_PROBE: !Ref EnableWriteProbe
           CANARY_GITHUB_TOKEN_SSM_PARAM: !If [HasGitHubReporter, !Ref GitHubTokenSsmParamName, '']
@@ -118,6 +138,13 @@ Resources:
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref DjCredentialsSecretArn
+          - !Ref AWS::NoValue
+        - !If
+          - HasLmlApiKey
+          - Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Ref LmlApiKeySecretArn
           - !Ref AWS::NoValue
         - !If
           - HasGitHubReporter

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -83,10 +83,10 @@ describe('runCanary — anonymous-only configuration', () => {
     vi.unstubAllGlobals();
   });
 
-  it('passes the 2 truly-anonymous checks and skips the 6 auth checks when no credentials are configured', async () => {
+  it('passes the 2 truly-anonymous checks and skips the 7 conditional checks when no credentials are configured', async () => {
     const outcomes = await runCanary(baseConfig);
 
-    expect(outcomes).toHaveLength(8);
+    expect(outcomes).toHaveLength(9);
     const byName = Object.fromEntries(outcomes.map((o) => [o.name, o]));
     expect(byName['backend-healthcheck'].status).toBe('pass');
     expect(byName['semantic-index-search'].status).toBe('pass');
@@ -96,6 +96,11 @@ describe('runCanary — anonymous-only configuration', () => {
     expect(byName['dj-rotation'].status).toBe('skipped');
     expect(byName['dj-rotation-picker'].status).toBe('skipped');
     expect(byName['enrichment-quality'].status).toBe('skipped');
+    // `lml-auth` skips on missing LML_API_KEY (operator gap) — same
+    // semantics as DJ credentials but a separate config switch. The
+    // `baseConfig` fixture leaves `lmlApiKey` undefined.
+    expect(byName['lml-auth'].status).toBe('skipped');
+    expect(byName['lml-auth'].message).toMatch(/no LML_API_KEY configured/);
   });
 });
 
@@ -294,6 +299,140 @@ describe('runCanary — failure surfaces (regression coverage for the 2026-04-30
     expect(dj.status).toBe('fail');
     expect(dj.message).toMatch(/auth precondition failed/);
     expect(dj.message).toMatch(/token exchange/);
+  });
+});
+
+/**
+ * `lml-auth` is the layer-1 mitigation for BS#1094 — silent
+ * `LML_API_KEY` rotation drift. It POSTs `/api/v1/lookup` directly to
+ * LML with the production bearer and asserts 200. 401/403 is the
+ * rotation-drift signal (distinct error message so the operator
+ * doesn't confuse it with LML being down); 5xx is the LML-down
+ * signal. Missing bearer is operator gap → skipped, not failed.
+ *
+ * URL match patterns here use the production LML host suffix because
+ * the `lml-auth` check hits LML directly, not via BS. `setUpFetchMock`
+ * matches on substring, so any unique part of the LML URL works; we
+ * use the full path `/api/v1/lookup` since the BS proxy uses the same
+ * substring fragment (`/library`), which would shadow this match
+ * otherwise.
+ */
+describe('runCanary — lml-auth check (BS#1094 layer 1)', () => {
+  const lmlAuthConfig: CanaryConfig = {
+    ...baseConfig,
+    // Distinct host so the check hits a substring no other mock matches.
+    lmlUrl: 'https://lml.example.test',
+    lmlApiKey: 'fake-lml-bearer',
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes when LML returns 200 to the authenticated lookup', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      'lml.example.test/api/v1/lookup': { status: 200, body: { results: [], cache_stats: {} } },
+    });
+
+    const outcomes = await runCanary(lmlAuthConfig);
+    const lml = outcomes.find((o) => o.name === 'lml-auth')!;
+    expect(lml.status).toBe('pass');
+  });
+
+  it('fails with a rotation-drift message when LML returns 401 (the BS#1094 incident shape)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      'lml.example.test/api/v1/lookup': { status: 401, body: { detail: 'Missing or invalid API key' } },
+    });
+
+    const outcomes = await runCanary(lmlAuthConfig);
+    const lml = outcomes.find((o) => o.name === 'lml-auth')!;
+
+    expect(lml.status).toBe('fail');
+    // The operator-facing distinction: rotation drift vs LML down. A
+    // generic "expected 2xx" message would lose the BS#1094 signal.
+    expect(lml.message).toMatch(/rotation drift/);
+    expect(lml.message).toMatch(/401/);
+  });
+
+  it('fails with the same rotation-drift message on 403 (forbidden — bearer recognised but revoked)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      'lml.example.test/api/v1/lookup': { status: 403, body: { detail: 'Forbidden' } },
+    });
+
+    const outcomes = await runCanary(lmlAuthConfig);
+    const lml = outcomes.find((o) => o.name === 'lml-auth')!;
+
+    expect(lml.status).toBe('fail');
+    expect(lml.message).toMatch(/rotation drift/);
+    expect(lml.message).toMatch(/403/);
+  });
+
+  it('fails with a generic 5xx message when LML itself is down (not a rotation-drift signal)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      'lml.example.test/api/v1/lookup': { status: 503, body: { detail: 'Service Unavailable' } },
+    });
+
+    const outcomes = await runCanary(lmlAuthConfig);
+    const lml = outcomes.find((o) => o.name === 'lml-auth')!;
+
+    expect(lml.status).toBe('fail');
+    // No rotation-drift framing — the operator's diagnostic path
+    // (page rom, page LML on-call) is different from rotation drift.
+    expect(lml.message).not.toMatch(/rotation drift/);
+    expect(lml.message).toMatch(/503/);
+  });
+
+  it('sends the bearer as Authorization: Bearer and posts a structured artist/album/song body', async () => {
+    const fetchMock = setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+      'lml.example.test/api/v1/lookup': { status: 200, body: { results: [], cache_stats: {} } },
+    });
+
+    await runCanary(lmlAuthConfig);
+
+    const lmlCall = fetchMock.mock.calls.find(([url]) => String(url).includes('lml.example.test/api/v1/lookup'));
+    expect(lmlCall).toBeDefined();
+    const [, init] = lmlCall as unknown as [unknown, RequestInit];
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer fake-lml-bearer');
+    expect(headers['Content-Type']).toBe('application/json');
+    // The payload must carry a real artist/album/song so it exercises
+    // LML's `perform_lookup` rather than short-circuiting on empty
+    // input. Use a canonical WXYC-representative fixture.
+    const body = JSON.parse(init.body as string);
+    expect(body.artist).toBeTypeOf('string');
+    expect(body.artist.length).toBeGreaterThan(0);
+    expect(body.album).toBeTypeOf('string');
+    expect(body.song).toBeTypeOf('string');
+  });
+
+  it('skips when no LML_API_KEY is configured (operator gap, not regression)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+    });
+
+    const outcomes = await runCanary({ ...baseConfig, lmlUrl: 'https://lml.example.test' });
+    const lml = outcomes.find((o) => o.name === 'lml-auth')!;
+
+    expect(lml.status).toBe('skipped');
+    expect(lml.message).toMatch(/no LML_API_KEY configured/);
   });
 });
 
@@ -511,9 +650,9 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     const dimensioned = checkFailureData.filter((d) => d.Dimensions && d.Dimensions.length > 0);
     const dimensionless = checkFailureData.filter((d) => !d.Dimensions || d.Dimensions.length === 0);
 
-    // Eight checks, each contributes one dimensioned and one dimensionless datapoint.
-    expect(dimensioned).toHaveLength(8);
-    expect(dimensionless).toHaveLength(8);
+    // Nine checks, each contributes one dimensioned and one dimensionless datapoint.
+    expect(dimensioned).toHaveLength(9);
+    expect(dimensionless).toHaveLength(9);
     // Without an inducer, every value is 0 (passes + skips).
     expect(dimensioned.every((d) => d.Value === 0)).toBe(true);
     expect(dimensionless.every((d) => d.Value === 0)).toBe(true);
@@ -545,7 +684,7 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     // isn't enough — `Statistic: Maximum` on the alarm needs at least one
     // `1` in the window, so this asserts the count of 1s explicitly.
     expect(dimensionless.filter((d) => d.Value === 1)).toHaveLength(1);
-    expect(dimensionless.filter((d) => d.Value === 0)).toHaveLength(7);
+    expect(dimensionless.filter((d) => d.Value === 0)).toHaveLength(8);
   });
 
   // `CheckSkipped` and `CheckLatency` are dashboard data, not alarm inputs.
@@ -566,8 +705,8 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     expect(metricData.filter((d) => d.MetricName === 'CheckSkipped' && isDimensionless(d))).toHaveLength(0);
     expect(metricData.filter((d) => d.MetricName === 'CheckLatency' && isDimensionless(d))).toHaveLength(0);
     // Sanity: the dimensioned series for each is present (one per check).
-    expect(metricData.filter((d) => d.MetricName === 'CheckSkipped')).toHaveLength(8);
-    expect(metricData.filter((d) => d.MetricName === 'CheckLatency')).toHaveLength(8);
+    expect(metricData.filter((d) => d.MetricName === 'CheckSkipped')).toHaveLength(9);
+    expect(metricData.filter((d) => d.MetricName === 'CheckLatency')).toHaveLength(9);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a new `lml-auth` canary check that POSTs `/api/v1/lookup` directly to LML production with `LML_API_KEY` and asserts 200. Distinct from `proxy-library-search` — that check goes through BS with a DJ JWT, so a missing bearer there fails as "BS lost the header" rather than "the LML bearer is stale". This check removes BS from the loop entirely.
- 401/403 surface as a rotation-drift fail message so the operator's diagnostic path matches the BS#1094 incident shape; 5xx falls back to a generic 2xx-expected message (different incident class, different mitigation).
- No `LML_API_KEY` configured → skipped (operator gap, mirrors the DJ-credentials shape). Secrets Manager resolve error → fail, because an IAM / SM regression is itself a real signal that warrants paging.
- Probe payload uses a canonical WXYC-representative fixture (Juana Molina / DOGA / la paradoja) from `wxyc-shared`'s example data so the request is indistinguishable from a real DJ lookup.

## Config

- `CANARY_LML_URL` (env) / `LmlUrl` (SAM param) — defaults to the prod Railway URL.
- `CANARY_LML_API_KEY` (env) for local + tests; `CANARY_LML_API_KEY_SECRET_ARN` (env) / `LmlApiKeySecretArn` (SAM param) for prod (plain-string SecretString — matches Railway's one-secret-one-value convention so the bearer rotates in one place across BS + rom + tubafrenzy + canary).
- Deploy workflow wires `secrets.LML_API_KEY_SECRET_ARN` + `vars.LML_URL`.

## Operator follow-ups (before this check goes from skipped → live)

1. Create a Secrets Manager secret containing the production `LML_API_KEY` as a plain string (not JSON). Suggested name: `wxyc-canary-lml-api-key`.
2. Add the resulting ARN as a GitHub secret named `LML_API_KEY_SECRET_ARN` on the `wxyc-canary` repo.
3. Trigger a redeploy. The `lml-auth` check will transition from `skipped` to `pass`/`fail`. Until step 1 lands, the check stays skipped and the `wxyc-canary-check-failure` alarm is quiet (operator gap is not regression).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm test` — 42/42 pass (added 6 new lml-auth tests, updated 4 existing tests for the 8 → 9 check-count delta)
- [x] `npm run build`
- [ ] After merge + redeploy with `LmlApiKeySecretArn` set: confirm the new check appears in the next invocation's CloudWatch metric publish (`Check=lml-auth` dimension on `CheckFailure` / `CheckSkipped` / `CheckLatency`).
- [ ] Smoke-test the rotation-drift signal by temporarily passing a bad bearer to the canary in a non-prod stack and confirming the `wxyc-canary-check-failure` alarm transitions to ALARM within ~10 min (2 of 3 evaluations).

## Scope

This is **layer 1** of the three-layer defense outlined in WXYC/Backend-Service#1094. Layer 2 (ship LML's `lml.auth.rejected` log to CloudWatch + alarm) and layer 3 (BS backfill orchestrator fail-fast on auth-class errors) are deferred per the BS#1279 Slot 3 close-out sequencing — separate work items in the parent epic.

Related to WXYC/Backend-Service#1094 (layer 1 of three; layers 2+3 deferred per BS#1279 Slot 3 scope).