### PR TITLE
Add MutationClientErrorSurgeAlarm targeting BS dimensionless companion

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -267,6 +267,38 @@ Resources:
       OKActions:
         - !Ref AlertTopic
 
+  # Backend-Service mutation 4xx surge alarm. Targets the dimensionless
+  # MutationClientError series Backend-Service publishes from the
+  # responseMetrics middleware (BS#704 added the dimensioned series,
+  # BS#845 / BS PR #1309 added the dimensionless companion required for
+  # plain-form alarming — see wxyc-canary#13 for the same trap on the
+  # canary side). Threshold 20 per 5-minute window over 2 of 2 windows
+  # means sustained >4/min for 10 minutes before paging, which absorbs
+  # deploy windows and one-off transient 4xx without alerting. Investigate
+  # via Sentry trace explorer — Sentry issues no longer carry 4xx after
+  # BS#691.
+  MutationClientErrorSurgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: wxyc-canary-mutation-4xx-surge
+      AlarmDescription: >
+        Sustained surge of 4xx responses on Backend-Service mutation routes
+        (POST/PATCH/DELETE /flowsheet/*). Investigate via Sentry trace
+        explorer — Sentry issues no longer carry 4xx after BS#691.
+      Namespace: WXYC/BackendService
+      MetricName: MutationClientError
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 20
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref AlertTopic
+      OKActions:
+        - !Ref AlertTopic
+
 Outputs:
   FunctionArn:
     Value: !GetAtt CanaryFunction.Arn


### PR DESCRIPTION
## Summary
- Add `MutationClientErrorSurgeAlarm` to `template.yaml`; the BS-side dimensionless companion landed via BS#845 ([PR #1309](https://github.com/WXYC/Backend-Service/pull/1309), merged 2026-06-03T17:25:45Z)
- Alarm uses the simple-form (Namespace + MetricName + Statistic), aligned with the `CheckFailure` precedent ([wxyc-canary#15](https://github.com/WXYC/wxyc-canary/pull/15) + [#16](https://github.com/WXYC/wxyc-canary/pull/16))

## AC verification status
- AC1 (`aws cloudwatch list-metrics ... MutationClientError` shows a dimensionless series): **deferred to first 4xx mutation in prod** — neither the dimensioned (from BS#704) nor dimensionless (from BS#1309) series is registered yet because zero 4xx mutations have fired in the last 24h. See [BS#845 comment 4615215769](https://github.com/WXYC/Backend-Service/issues/845#issuecomment-4615215769). `TreatMissingData: notBreaching` makes the alarm start in OK state regardless.
- AC2 (resource added): satisfied by this PR.
- AC3 (alarm INSUFFICIENT_DATA → OK within 15 min): satisfied immediately by `TreatMissingData: notBreaching`.
- AC4 (no regression test required): noted; the contract pin lives in BS's `responseMetrics.test.ts` and the alarm's wire shape is enforced by SAM/CFN deploy validation. The local `template.yaml ↔ publishMetrics contract` test deliberately skips `WXYC/BackendService` alarms (only validates `WXYC/Canary` alarms against handler emissions).

## Local pre-flight
- `npm run typecheck` — clean
- `npm test` — 45/45 passing (includes the contract test, which excludes this alarm by namespace as designed)
- `npm run format:check` — clean
- `sam validate` — valid SAM template. (`sam validate --lint` reports a pre-existing `LmlUrl` parameter-description warning on `origin/main`, unrelated to this change.)

## Closes
Closes #17