### PR TITLE
Add gha-runner-online check (staging-gate runner liveness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@ The canary exists because three production incidents on 2026-04-30 (catalog-sear
 
 ## What it checks
 
-| Check                   | Endpoint                                                                                                                                        | Auth             | What it would have caught                                                                                                                                                                                                                             |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `backend-healthcheck`   | `GET /healthcheck`                                                                                                                              | none             | Process-level outage on Backend-Service                                                                                                                                                                                                               |
-| `proxy-library-search`  | `GET /proxy/library/search?artist=Stereolab&limit=5`                                                                                            | anonymous device | LML degradation, BS proxy regressions                                                                                                                                                                                                                 |
-| `semantic-index-search` | `GET https://explore.wxyc.org/graph/artists/search?q=Stereolab&limit=1`                                                                         | none             | semantic-index 5xx; missing `results` envelope                                                                                                                                                                                                        |
-| `dj-library-search`     | `GET /library/?artist_name=Stereolab&n=5`                                                                                                       | DJ JWT           | The 2026-04-30 catalog-search 503 incident, exactly                                                                                                                                                                                                   |
-| `dj-flowsheet-read`     | `GET /v2/flowsheet?n=5`                                                                                                                         | DJ JWT           | V2 flowsheet read regressions                                                                                                                                                                                                                         |
-| `dj-rotation`           | `GET /library/rotation`                                                                                                                         | DJ JWT           | Rotation endpoint 5xx, fully empty rotation                                                                                                                                                                                                           |
-| `dj-rotation-picker`    | `GET /library/rotation/{id}/tracks` (id discovered from list)                                                                                   | DJ JWT           | The BS#994 / BS#1030 cascade-to-502 class; LML-cascade timeouts on the picker that previously surfaced via on-air Slack                                                                                                                               |
-| `lml-auth`              | `POST /api/v1/lookup` directly to LML — twice, once with `LML_API_KEY` (assert 2xx) and once with a synthetic known-bad bearer (assert 401/403) | LML bearer       | BS#1094 `LML_API_KEY` rotation drift (good-bearer 401/403); LML auth disabled regression (known-bad bearer 200, i.e. `LML_REQUIRE_AUTH=false` flip or rollback); LML down (5xx). Distinct error messages route the operator to the right remediation. |
-| `enrichment-quality`    | insert sentinel → poll for enrichment → delete                                                                                                  | DJ JWT (write)   | The 2026-05-13 LML cascade regression (null-metadata on inserts)                                                                                                                                                                                      |
+| Check                   | Endpoint                                                                                                                                        | Auth             | What it would have caught                                                                                                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend-healthcheck`   | `GET /healthcheck`                                                                                                                              | none             | Process-level outage on Backend-Service                                                                                                                                                                                                                    |
+| `proxy-library-search`  | `GET /proxy/library/search?artist=Stereolab&limit=5`                                                                                            | anonymous device | LML degradation, BS proxy regressions                                                                                                                                                                                                                      |
+| `semantic-index-search` | `GET https://explore.wxyc.org/graph/artists/search?q=Stereolab&limit=1`                                                                         | none             | semantic-index 5xx; missing `results` envelope                                                                                                                                                                                                             |
+| `dj-library-search`     | `GET /library/?artist_name=Stereolab&n=5`                                                                                                       | DJ JWT           | The 2026-04-30 catalog-search 503 incident, exactly                                                                                                                                                                                                        |
+| `dj-flowsheet-read`     | `GET /v2/flowsheet?n=5`                                                                                                                         | DJ JWT           | V2 flowsheet read regressions                                                                                                                                                                                                                              |
+| `dj-rotation`           | `GET /library/rotation`                                                                                                                         | DJ JWT           | Rotation endpoint 5xx, fully empty rotation                                                                                                                                                                                                                |
+| `dj-rotation-picker`    | `GET /library/rotation/{id}/tracks` (id discovered from list)                                                                                   | DJ JWT           | The BS#994 / BS#1030 cascade-to-502 class; LML-cascade timeouts on the picker that previously surfaced via on-air Slack                                                                                                                                    |
+| `lml-auth`              | `POST /api/v1/lookup` directly to LML — twice, once with `LML_API_KEY` (assert 2xx) and once with a synthetic known-bad bearer (assert 401/403) | LML bearer       | BS#1094 `LML_API_KEY` rotation drift (good-bearer 401/403); LML auth disabled regression (known-bad bearer 200, i.e. `LML_REQUIRE_AUTH=false` flip or rollback); LML down (5xx). Distinct error messages route the operator to the right remediation.      |
+| `gha-runner-online`     | `GET /orgs/{org}/actions/runners/{id}`                                                                                                          | GH PAT           | Staging-gate runner host wedge / systemd unit death / network egress break — the on-call signal the EC2-hosted runner (WXYC/wiki#80 phase 1) needs replacing or rebooting. Distinct messages route offline vs 404 (runner replaced) vs 401 (PAT rotation). |
+| `enrichment-quality`    | insert sentinel → poll for enrichment → delete                                                                                                  | DJ JWT (write)   | The 2026-05-13 LML cascade regression (null-metadata on inserts)                                                                                                                                                                                           |
 
-DJ-auth checks downgrade to `skipped` (a distinct CloudWatch metric, not `failed`) when no DJ credentials are configured, so the alarm doesn't fire on operator-caused gaps. The `lml-auth` check follows the same shape: it skips when no `LML_API_KEY` is configured. The `enrichment-quality` write canary additionally requires `CANARY_ENABLE_WRITE_PROBE=true` and skips when another DJ is on-air — the canary deliberately doesn't inject sentinel rows into a real DJ's flowsheet.
+DJ-auth checks downgrade to `skipped` (a distinct CloudWatch metric, not `failed`) when no DJ credentials are configured, so the alarm doesn't fire on operator-caused gaps. The `lml-auth` check follows the same shape: it skips when no `LML_API_KEY` is configured. The `gha-runner-online` check skips when no GitHub PAT or runner id is configured. The `enrichment-quality` write canary additionally requires `CANARY_ENABLE_WRITE_PROBE=true` and skips when another DJ is on-air — the canary deliberately doesn't inject sentinel rows into a real DJ's flowsheet.
 
 ## Architecture
 
@@ -147,6 +148,42 @@ Dedup key is the `canary:check:{name}` label, not the title. Labels are durable 
 
 To turn off GitHub-issue reporting, redeploy with empty `GitHubTokenSsmParamName` (the conditional in `template.yaml` then removes the SSM IAM grant and env vars).
 
+### Runner liveness probe (`gha-runner-online`)
+
+The `gha-runner-online` check polls the WXYC org's self-hosted GitHub Actions runner that hosts the staging-gate E2E suites (WXYC/wiki#80 phase 1 — see wxyc-shared `scripts/e2e-runner/README.md` for the runner bootstrap + topology). It calls `GET /orgs/WXYC/actions/runners/{id}` every five minutes and fails when `status != "online"`. The existing `wxyc-canary-check-failure` alarm (3 evaluations × 5 min, 2 datapoints to alarm) gives the spec's ≥10 minutes of sustained breach for free — no new alarm.
+
+1. Create a GitHub fine-scoped PAT:
+   - Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token.
+   - **Resource owner**: `WXYC`. **Repository access**: doesn't matter — this is an org-scoped permission.
+   - **Permissions** → **Organization permissions** → **Self-hosted runners**: Read.
+   - No other scopes. Set a reasonable expiry and a calendar reminder to rotate.
+2. Store it in SSM as a SecureString. Keep it under `/wxyc-canary/*` so it shares the rotation cadence and IAM grant pattern with the GitHub-issues reporter PAT:
+   ```bash
+   aws ssm put-parameter \
+     --name /wxyc-canary/gha-runner-token \
+     --type SecureString \
+     --value "$PAT" \
+     --description "PAT for wxyc-canary runner-liveness probe. Rotate by overwriting with --overwrite."
+   ```
+3. Discover the runner id (changes on re-registration):
+   ```bash
+   gh api /orgs/WXYC/actions/runners \
+     --jq '.runners[] | select(.name=="wxyc-e2e-runner") | {id, status, labels: [.labels[].name]}'
+   ```
+4. Pass three stack parameters on the next deploy:
+   ```bash
+   sam deploy \
+     --parameter-overrides \
+       GhaRunnerTokenSsmParamName=/wxyc-canary/gha-runner-token \
+       GhaRunnerOrg=WXYC \
+       GhaRunnerId=<id from step 3> \
+       # ...other params
+   ```
+
+When the runner is replaced (instance swap or re-registration), repeat step 3 and redeploy with the new `GhaRunnerId`. The check will fail with a 404-flavoured message until the parameter is re-set — that's intentional, since a stale `GhaRunnerId` is itself a real signal the operator should fix.
+
+To turn the probe off, redeploy with an empty `GhaRunnerTokenSsmParamName` or `GhaRunnerId=0`. The conditional in `template.yaml` then strips the SSM IAM grant and the env vars; the check downgrades to `skipped` and the alarm stays quiet.
+
 ### CI deploys
 
 `.github/workflows/deploy.yml` builds + deploys on push to `main`. Required GitHub secrets:
@@ -166,6 +203,14 @@ Required GitHub variables (override defaults if needed):
 2. Tail the canary log: `aws logs tail /aws/lambda/wxyc-canary --since 30m`. Each invocation prints a JSON line with all six outcomes.
 3. Reproduce the failing endpoint manually (the `description` column above tells you the URL).
 4. If the failure is real, page the on-call. If the canary itself is buggy, file an issue and disable the check by removing it from `src/checks.ts`.
+
+### Alarm fires: `wxyc-canary-check-failure` (`Check=gha-runner-online`)
+
+The staging-gate runner has been failing its liveness probe for ≥10 minutes. The check message distinguishes the failure mode — route accordingly:
+
+- **`offline`** — the runner process stopped polling GitHub. SSH to `wxyc-e2e-runner` (per wxyc-shared `scripts/e2e-runner/README.md`) and check `systemctl status 'actions.runner.*.service'`. If the host itself is unreachable, the EC2 instance is wedged — reboot or rebuild from the bootstrap script.
+- **`404 — runner was likely replaced`** — someone replaced the runner without re-setting `GhaRunnerId`. Discover the new id with `gh api /orgs/WXYC/actions/runners --jq '.runners[] | select(.name=="wxyc-e2e-runner")'` and redeploy with the updated parameter.
+- **`PAT rejected with 401/403`** — the SSM-stored PAT was revoked, scoped down, or expired. Generate a fresh fine-scoped PAT (Self-hosted runners: Read on `WXYC`) and overwrite `/wxyc-canary/gha-runner-token` via `aws ssm put-parameter --overwrite`.
 
 ### Alarm fires: `wxyc-canary-lambda-errors`
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,11 @@ Required GitHub variables (override defaults if needed):
 The staging-gate runner has been failing its liveness probe for ≥10 minutes. The check message distinguishes the failure mode — route accordingly:
 
 - **`offline`** — the runner process stopped polling GitHub. SSH to `wxyc-e2e-runner` (per wxyc-shared `scripts/e2e-runner/README.md`) and check `systemctl status 'actions.runner.*.service'`. If the host itself is unreachable, the EC2 instance is wedged — reboot or rebuild from the bootstrap script.
-- **`404 — runner was likely replaced`** — someone replaced the runner without re-setting `GhaRunnerId`. Discover the new id with `gh api /orgs/WXYC/actions/runners --jq '.runners[] | select(.name=="wxyc-e2e-runner")'` and redeploy with the updated parameter.
-- **`PAT rejected with 401/403`** — the SSM-stored PAT was revoked, scoped down, or expired. Generate a fresh fine-scoped PAT (Self-hosted runners: Read on `WXYC`) and overwrite `/wxyc-canary/gha-runner-token` via `aws ssm put-parameter --overwrite`.
+- **`404 — runner was likely replaced (or PAT lacks Self-hosted runners: Read scope)`** — two-step diagnosis: (1) Confirm the runner id is still current with `gh api /orgs/WXYC/actions/runners --jq '.runners[] | select(.name=="wxyc-e2e-runner")'`. If the id changed, redeploy with the new `GhaRunnerId`. (2) If the id is unchanged, the PAT is missing the `Self-hosted runners: Read` org-level permission — GitHub returns 404 to hide resources from underprivileged tokens. Generate a fresh fine-scoped PAT with the correct scope and overwrite `/wxyc-canary/gha-runner-token`.
+- **`GitHub rate limit exceeded — the PAT is valid`** — do NOT rotate the PAT. The 5000/hr REST bucket is shared across everything the PAT identity touches; wait for the reset epoch in the message and investigate any other tooling that may share the token.
+- **`GitHub API degraded`** — check [githubstatus.com](https://www.githubstatus.com) before SSHing the runner or rotating anything. The runner is fine; GitHub itself is the problem.
+- **`PAT rejected with 401`** — the SSM-stored PAT was revoked, expired, or malformed. Generate a fresh fine-scoped PAT (Self-hosted runners: Read on `WXYC`) and overwrite `/wxyc-canary/gha-runner-token` via `aws ssm put-parameter --overwrite`.
+- **`PAT rejected with 403`** — same remediation as 401, but only after ruling out the rate-limit message (which also surfaces as 403).
 
 ### Alarm fires: `wxyc-canary-lambda-errors`
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -299,6 +299,82 @@ const lmlAuth: Check = {
 };
 
 /**
+ * Liveness probe for the EC2-hosted self-hosted GitHub Actions runner
+ * (label `e2e-runner`) that backs the staging-gate suites in
+ * Backend-Service, library-metadata-lookup, and dj-site. Wired up as
+ * part of WXYC/wiki#80 phase 1; the runner bootstrap + runbook live in
+ * wxyc-shared (`scripts/e2e-runner/`).
+ *
+ * Probe: `GET /orgs/{org}/actions/runners/{id}` with a fine-scoped PAT.
+ * Pass on `status === "online"`. Fail on any other status (`offline`
+ * is the spec's primary failure mode), 404 (runner id no longer exists
+ * after a host replacement that didn't re-set the stack parameter),
+ * 401/403 (PAT rotation drift), or 5xx (GitHub itself degraded — rare
+ * but distinct enough to surface separately).
+ *
+ * The existing `wxyc-canary-check-failure` alarm gives the spec's
+ * "≥10 minutes of `status != online`" window for free: 3 evaluations ×
+ * 5 min, 2 datapoints to alarm = ~10 min sustained breach. No new
+ * alarm needed.
+ *
+ * Skip semantics mirror `lml-auth` / DJ credentials: missing PAT or
+ * runner-id is an operator gap (alarm stays quiet), but a downstream
+ * resolution error fails (real signal, paged).
+ */
+const ghaRunnerOnline: Check = {
+  name: 'gha-runner-online',
+  description: 'GET /orgs/{org}/actions/runners/{id} — staging-gate runner liveness',
+  requiresAuth: false,
+  run: async (ctx): Promise<CheckResult | void> => {
+    if (!ctx.ghaRunnerToken) {
+      return { skipped: true, skipReason: 'no GitHub PAT configured for runner-liveness probe' };
+    }
+    if (typeof ctx.ghaRunnerId !== 'number') {
+      return { skipped: true, skipReason: 'no runner id configured (CANARY_GHA_RUNNER_ID)' };
+    }
+    const url = `${ctx.ghaRunnerApiBase}/orgs/${ctx.ghaRunnerOrg}/actions/runners/${ctx.ghaRunnerId}`;
+    const r = await canaryFetch(url, {
+      headers: {
+        Authorization: `Bearer ${ctx.ghaRunnerToken}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (r.status === 404) {
+      // Runner id no longer exists — the operator replaced the host and
+      // did not re-set the CFN parameter. Distinct from "offline" so the
+      // on-call routes to the replacement runbook, not "the runner died".
+      throw new Error(
+        `GitHub returned 404 for runner id ${ctx.ghaRunnerId} — runner was likely replaced; re-set GhaRunnerId stack parameter: ${r.rawText.slice(0, 200)}`
+      );
+    }
+    if (r.status === 401 || r.status === 403) {
+      // PAT is revoked / unscoped / expired. Operator action: rotate
+      // the SSM parameter — different runbook entry from "runner down".
+      throw new Error(
+        `GitHub rejected PAT with ${r.status} — rotate the runner-liveness PAT in SSM: ${r.rawText.slice(0, 200)}`
+      );
+    }
+    if (!r.ok) {
+      throw new Error(`expected 2xx from GitHub runner endpoint, got ${r.status}: ${r.rawText.slice(0, 200)}`);
+    }
+    const body = r.body as { status?: string; name?: string; id?: number };
+    if (!body || typeof body !== 'object' || typeof body.status !== 'string') {
+      throw new Error(`expected {status: string} from GitHub runner endpoint, got: ${r.rawText.slice(0, 200)}`);
+    }
+    if (body.status !== 'online') {
+      // The spec's primary failure mode: the runner stopped polling
+      // GitHub (host wedge, systemd unit died, network egress to
+      // github.com broken). Include the human-readable name so the
+      // alarm message points the on-call at the right host.
+      throw new Error(
+        `runner ${body.name ?? `id=${ctx.ghaRunnerId}`} is offline (status="${body.status}") — investigate per scripts/e2e-runner/README.md`
+      );
+    }
+  },
+};
+
+/**
  * Write canary (v1). Inserts a sentinel flowsheet row, polls until LML
  * enrichment populates `youtube_music_url`, deletes the row, ends the
  * canary's show. Returns an `EnrichmentLagSeconds` metric the runner
@@ -331,6 +407,7 @@ export const checks: readonly Check[] = [
   djRotation,
   djRotationPicker,
   lmlAuth,
+  ghaRunnerOnline,
   enrichmentQuality,
 ];
 

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -326,13 +326,38 @@ const ghaRunnerOnline: Check = {
   description: 'GET /orgs/{org}/actions/runners/{id} — staging-gate runner liveness',
   requiresAuth: false,
   run: async (ctx): Promise<CheckResult | void> => {
+    // Check the runner-id sentinel before the token: when both are missing
+    // the id is the load-bearing knob (a configured probe without a token
+    // would fail to resolve; a configured token without an id would have
+    // nothing to probe). Surfacing "no runner id" first matches the
+    // dominant operator failure mode.
+    //
+    // Defense-in-depth on the runner-id sentinel. The CFN HasGhaRunnerProbe
+    // condition strips the env var to '' when GhaRunnerId=0; the env loader
+    // turns '' into undefined. But non-CFN deploy paths (local invoke, manual
+    // env override, a future template refactor) can land NaN (typo) or 0
+    // (sentinel) or non-positive-integer values. `typeof NaN === 'number'`
+    // and `typeof 0 === 'number'`, so a bare `typeof !== 'number'` is not
+    // enough — without isInteger/`> 0` the URL would template `/runners/NaN`
+    // or `/runners/0` and 404, mis-routing to "runner was likely replaced".
+    if (typeof ctx.ghaRunnerId !== 'number' || !Number.isInteger(ctx.ghaRunnerId) || ctx.ghaRunnerId <= 0) {
+      return {
+        skipped: true,
+        skipReason:
+          ctx.ghaRunnerId === undefined
+            ? 'no runner id configured (CANARY_GHA_RUNNER_ID)'
+            : `invalid runner id (CANARY_GHA_RUNNER_ID=${ctx.ghaRunnerId}); expected positive integer`,
+      };
+    }
     if (!ctx.ghaRunnerToken) {
       return { skipped: true, skipReason: 'no GitHub PAT configured for runner-liveness probe' };
     }
-    if (typeof ctx.ghaRunnerId !== 'number') {
-      return { skipped: true, skipReason: 'no runner id configured (CANARY_GHA_RUNNER_ID)' };
-    }
-    const url = `${ctx.ghaRunnerApiBase}/orgs/${ctx.ghaRunnerOrg}/actions/runners/${ctx.ghaRunnerId}`;
+    // Normalize a trailing slash on the API base. Operator copy-paste
+    // hazard — GH today tolerates `//orgs/...` but a path-strict proxy or
+    // future GH rev would 404 and the failure would mis-route through the
+    // "runner replaced" runbook.
+    const apiBase = ctx.ghaRunnerApiBase.replace(/\/+$/, '');
+    const url = `${apiBase}/orgs/${ctx.ghaRunnerOrg}/actions/runners/${ctx.ghaRunnerId}`;
     const r = await canaryFetch(url, {
       headers: {
         Authorization: `Bearer ${ctx.ghaRunnerToken}`,
@@ -344,15 +369,49 @@ const ghaRunnerOnline: Check = {
       // Runner id no longer exists — the operator replaced the host and
       // did not re-set the CFN parameter. Distinct from "offline" so the
       // on-call routes to the replacement runbook, not "the runner died".
+      // NOTE: a fine-scoped PAT with insufficient scope ALSO returns 404
+      // (GitHub hides resources from underprivileged tokens). The runbook
+      // entry for this message must mention the PAT-scope possibility as a
+      // second-line check after the operator confirms the runner id.
       throw new Error(
-        `GitHub returned 404 for runner id ${ctx.ghaRunnerId} — runner was likely replaced; re-set GhaRunnerId stack parameter: ${r.rawText.slice(0, 200)}`
+        `GitHub returned 404 for runner id ${ctx.ghaRunnerId} — runner was likely replaced (or PAT lacks Self-hosted runners: Read scope); re-set GhaRunnerId or rotate PAT: ${r.rawText.slice(0, 200)}`
       );
     }
-    if (r.status === 401 || r.status === 403) {
-      // PAT is revoked / unscoped / expired. Operator action: rotate
-      // the SSM parameter — different runbook entry from "runner down".
+    if (r.status === 403) {
+      // 403 is overloaded: primary rate-limit returns 403 with `X-RateLimit-
+      // Remaining: 0` and a body mentioning "rate limit". PAT rotation
+      // drift returns 403 too. Disambiguate so on-call doesn't rotate a
+      // perfectly valid PAT chasing a transient rate-limit window.
+      const remaining = r.headers?.['x-ratelimit-remaining'];
+      const bodyText = r.rawText.toLowerCase();
+      if (remaining === '0' || bodyText.includes('rate limit') || bodyText.includes('secondary rate')) {
+        const reset = r.headers?.['x-ratelimit-reset'];
+        const resetSuffix = reset ? ` (reset epoch ${reset})` : '';
+        // Phrased to keep the on-call away from PAT-rotation actions: the
+        // PAT is valid; the bucket needs to refill.
+        throw new Error(
+          `GitHub rate limit exceeded${resetSuffix} — wait for the bucket to reset; the PAT is valid: ${r.rawText.slice(0, 200)}`
+        );
+      }
       throw new Error(
-        `GitHub rejected PAT with ${r.status} — rotate the runner-liveness PAT in SSM: ${r.rawText.slice(0, 200)}`
+        `GitHub rejected PAT with 403 — rotate the runner-liveness PAT in SSM: ${r.rawText.slice(0, 200)}`
+      );
+    }
+    if (r.status === 401) {
+      // PAT is revoked / expired / malformed. Operator action: rotate the
+      // SSM parameter — different runbook entry from "runner down" or "rate
+      // limit".
+      throw new Error(
+        `GitHub rejected PAT with 401 — rotate the runner-liveness PAT in SSM: ${r.rawText.slice(0, 200)}`
+      );
+    }
+    if (r.status >= 500) {
+      // GitHub itself is degraded. Route the on-call to githubstatus.com
+      // before they SSH the runner or rotate the PAT — the runner has
+      // nothing to do with this failure. The docstring above promised this
+      // would be a distinct surface; here it actually is.
+      throw new Error(
+        `GitHub API degraded (status ${r.status}) — check githubstatus.com before investigating the runner: ${r.rawText.slice(0, 200)}`
       );
     }
     if (!r.ok) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -36,6 +36,10 @@ function loadConfigFromEnv(): CanaryConfig {
       : undefined,
     ghaRunnerApiBase: process.env.CANARY_GHA_RUNNER_API_BASE,
     ghaRunnerOrg: process.env.CANARY_GHA_RUNNER_ORG,
+    // Pass NaN through verbatim: the check layer treats anything that isn't
+    // a positive integer as "skip with invalid-id reason", so an operator
+    // typo (e.g. CANARY_GHA_RUNNER_ID=abc → Number → NaN) surfaces as a
+    // skipped check with a precise reason rather than a misrouted 404.
     ghaRunnerId: process.env.CANARY_GHA_RUNNER_ID ? Number(process.env.CANARY_GHA_RUNNER_ID) : undefined,
     ghaRunnerToken: process.env.CANARY_GHA_RUNNER_TOKEN,
   };
@@ -143,15 +147,28 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
     lmlAuthError = `LML bearer resolution failed: ${(err as Error).message}`;
   }
 
-  // GH runner PAT resolution: same shape as lml-auth — skip on absence,
-  // fail on resolve errors. SSM outage / IAM regression here would
-  // silently disable the runner-liveness probe if collapsed to "skipped".
+  // GH runner PAT resolution: skip when the probe isn't configured at all
+  // (no runner-id → check would skip anyway), fail when it IS configured
+  // and resolution errors (SSM outage / IAM regression — real signal).
+  // Asymmetric vs lml-auth on purpose: lml-auth has one knob, this probe
+  // has two; resolving the PAT when the operator forgot the runner-id half
+  // would page on-call for a probe that wouldn't have run.
   let ghaRunnerToken: string | undefined;
   let ghaRunnerTokenError: string | undefined;
-  try {
-    ghaRunnerToken = await resolveGhaRunnerToken(config);
-  } catch (err) {
-    ghaRunnerTokenError = `GH runner PAT resolution failed: ${(err as Error).message}`;
+  const probeIdConfigured =
+    typeof config.ghaRunnerId === 'number' && Number.isInteger(config.ghaRunnerId) && config.ghaRunnerId > 0;
+  if (probeIdConfigured) {
+    try {
+      ghaRunnerToken = await resolveGhaRunnerToken(config);
+    } catch (err) {
+      ghaRunnerTokenError = `GH runner PAT resolution failed: ${(err as Error).message}`;
+    }
+  } else {
+    // Still resolve the inline (env-provided) token so tests / local runs
+    // that pass `ghaRunnerToken` directly through CanaryConfig continue to
+    // work even when no runner-id is set. The check will skip; the token
+    // is just threaded through ctx for completeness.
+    ghaRunnerToken = config.ghaRunnerToken;
   }
 
   let djBearerToken: string | undefined;
@@ -185,8 +202,15 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
     djUserId,
     enrichmentPollTimeoutMs: config.enrichmentPollTimeoutMs ?? DEFAULT_ENRICHMENT_POLL_TIMEOUT_MS,
     enrichmentPollIntervalMs: config.enrichmentPollIntervalMs ?? DEFAULT_ENRICHMENT_POLL_INTERVAL_MS,
-    ghaRunnerApiBase: config.ghaRunnerApiBase ?? 'https://api.github.com',
-    ghaRunnerOrg: config.ghaRunnerOrg ?? 'WXYC',
+    // `||` (not `??`) on the two string defaults so an empty-string env
+    // value also picks up the default. The CFN template wires
+    // CANARY_GHA_RUNNER_ORG unconditionally, so even probe-disabled stacks
+    // forward 'WXYC' here; but a future template change that sets either
+    // to '' (or a manual override) must NOT compose a URL like
+    // `/orgs//actions/...` and 404 with a misleading "runner replaced"
+    // failure.
+    ghaRunnerApiBase: config.ghaRunnerApiBase || 'https://api.github.com',
+    ghaRunnerOrg: config.ghaRunnerOrg || 'WXYC',
     ghaRunnerId: config.ghaRunnerId,
     ghaRunnerToken,
   };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -34,6 +34,10 @@ function loadConfigFromEnv(): CanaryConfig {
     enrichmentPollIntervalMs: process.env.CANARY_ENRICHMENT_POLL_INTERVAL_MS
       ? Number(process.env.CANARY_ENRICHMENT_POLL_INTERVAL_MS)
       : undefined,
+    ghaRunnerApiBase: process.env.CANARY_GHA_RUNNER_API_BASE,
+    ghaRunnerOrg: process.env.CANARY_GHA_RUNNER_ORG,
+    ghaRunnerId: process.env.CANARY_GHA_RUNNER_ID ? Number(process.env.CANARY_GHA_RUNNER_ID) : undefined,
+    ghaRunnerToken: process.env.CANARY_GHA_RUNNER_TOKEN,
   };
 }
 
@@ -88,6 +92,30 @@ async function resolveLmlApiKey(config: CanaryConfig): Promise<string | undefine
 }
 
 /**
+ * Resolve the GitHub PAT used by the `gha-runner-online` check, in order:
+ *   1. `CANARY_GHA_RUNNER_TOKEN` env (local + tests).
+ *   2. `CANARY_GHA_RUNNER_TOKEN_SSM_PARAM` → SSM SecureString (prod).
+ * Returns undefined when neither is configured — the check then skips
+ * with reason. The PAT is stored in SSM (not Secrets Manager) to match
+ * the existing GitHub-issues-reporter PAT, which keeps all GitHub-PAT
+ * storage co-located under `/wxyc-canary/*` for the same rotation
+ * cadence and IAM grant pattern.
+ */
+async function resolveGhaRunnerToken(config: CanaryConfig): Promise<string | undefined> {
+  if (config.ghaRunnerToken) return config.ghaRunnerToken;
+  const paramName = process.env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM;
+  if (!paramName) return undefined;
+
+  const ssm = new SSMClient({ region: config.awsRegion ?? 'us-east-1' });
+  const result = await ssm.send(new GetParameterCommand({ Name: paramName, WithDecryption: true }));
+  const value = result.Parameter?.Value;
+  if (!value) {
+    throw new Error(`SSM parameter ${paramName} has no Value`);
+  }
+  return value;
+}
+
+/**
  * Run every check, regardless of individual failures. Returns one outcome
  * per check. DJ-auth checks downgrade to 'skipped' when no DJ credentials
  * are configured — distinct from 'fail' so the alarm only fires on real
@@ -113,6 +141,17 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
     lmlApiKey = await resolveLmlApiKey(config);
   } catch (err) {
     lmlAuthError = `LML bearer resolution failed: ${(err as Error).message}`;
+  }
+
+  // GH runner PAT resolution: same shape as lml-auth — skip on absence,
+  // fail on resolve errors. SSM outage / IAM regression here would
+  // silently disable the runner-liveness probe if collapsed to "skipped".
+  let ghaRunnerToken: string | undefined;
+  let ghaRunnerTokenError: string | undefined;
+  try {
+    ghaRunnerToken = await resolveGhaRunnerToken(config);
+  } catch (err) {
+    ghaRunnerTokenError = `GH runner PAT resolution failed: ${(err as Error).message}`;
   }
 
   let djBearerToken: string | undefined;
@@ -146,6 +185,10 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
     djUserId,
     enrichmentPollTimeoutMs: config.enrichmentPollTimeoutMs ?? DEFAULT_ENRICHMENT_POLL_TIMEOUT_MS,
     enrichmentPollIntervalMs: config.enrichmentPollIntervalMs ?? DEFAULT_ENRICHMENT_POLL_INTERVAL_MS,
+    ghaRunnerApiBase: config.ghaRunnerApiBase ?? 'https://api.github.com',
+    ghaRunnerOrg: config.ghaRunnerOrg ?? 'WXYC',
+    ghaRunnerId: config.ghaRunnerId,
+    ghaRunnerToken,
   };
 
   const outcomes = await Promise.all(
@@ -161,6 +204,12 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
       // signal that warrants paging, not a silent skip.
       if (check.name === 'lml-auth' && lmlAuthError) {
         return { name: check.name, status: 'fail', latencyMs: 0, message: lmlAuthError };
+      }
+      // Same rule for gha-runner-online: an SSM outage / IAM regression
+      // is a real signal; collapsing to "skipped" would silently disable
+      // the runner-liveness probe.
+      if (check.name === 'gha-runner-online' && ghaRunnerTokenError) {
+        return { name: check.name, status: 'fail', latencyMs: 0, message: ghaRunnerTokenError };
       }
       if (check.writes && !config.enableWriteProbe) {
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,32 @@ export type CheckContext = {
   enrichmentPollTimeoutMs: number;
   /** Spacing between poll iterations for the enrichment-quality check. */
   enrichmentPollIntervalMs: number;
+  /**
+   * GitHub REST API base for the runner-liveness probe (no trailing
+   * slash). Defaults to `https://api.github.com` in the handler when
+   * unset; overridable so tests can route to a synthetic host.
+   */
+  ghaRunnerApiBase: string;
+  /**
+   * GitHub organization that owns the self-hosted runner. Defaults to
+   * `WXYC`.
+   */
+  ghaRunnerOrg: string;
+  /**
+   * Numeric runner id assigned by GitHub on registration. Required for
+   * the `gha-runner-online` check to run — undefined → skip with reason.
+   * The id changes when the runner is replaced (re-registration), so
+   * the operator must re-set the CFN parameter after an instance swap.
+   */
+  ghaRunnerId: number | undefined;
+  /**
+   * Fine-scoped PAT with `admin:org → Self-hosted runners: Read`
+   * (classic) or the fine-grained equivalent (`Administration` /
+   * `Self-hosted runners` on the org). Undefined → check skips.
+   * Resolution errors (Secrets Manager / SSM IAM regressions) fail
+   * rather than skip, mirroring the lml-auth bearer-resolution path.
+   */
+  ghaRunnerToken: string | undefined;
 };
 
 export type CheckOutcome = {
@@ -141,4 +167,18 @@ export type CanaryConfig = {
   enrichmentPollTimeoutMs?: number;
   /** See CheckContext.enrichmentPollIntervalMs. */
   enrichmentPollIntervalMs?: number;
+  /** See CheckContext.ghaRunnerApiBase. */
+  ghaRunnerApiBase?: string;
+  /** See CheckContext.ghaRunnerOrg. */
+  ghaRunnerOrg?: string;
+  /** See CheckContext.ghaRunnerId. */
+  ghaRunnerId?: number;
+  /**
+   * GH PAT for the runner-liveness probe. Either set this directly
+   * (`CANARY_GHA_RUNNER_TOKEN` env, local/test) or set
+   * `CANARY_GHA_RUNNER_TOKEN_SSM_PARAM` for SSM SecureString resolution
+   * (prod). When unset and no SSM param is configured, the
+   * `gha-runner-online` check downgrades to skipped.
+   */
+  ghaRunnerToken?: string;
 };

--- a/template.yaml
+++ b/template.yaml
@@ -119,8 +119,12 @@ Parameters:
       The id changes when the runner is replaced (re-registration), so
       this parameter must be re-set after an instance swap — see
       wxyc-shared `scripts/e2e-runner/README.md`. Leave at 0 to skip the
-      probe (the check downgrades to skipped, no alarm). The handler
-      forwards 0 verbatim; the check skips on "no runner id configured".
+      probe (the check downgrades to skipped, no alarm). Disabling
+      mechanism: the `HasGhaRunnerProbe` condition sets the env var to
+      empty string when this parameter is 0, which the handler env loader
+      reads as undefined; the check's own runner-id guard
+      (`Number.isInteger(id) && id > 0`) is the second line of defense
+      for any non-CFN deploy path (local invoke, manual env override).
 
 Conditions:
   HasDjCredentials: !Not [!Equals [!Ref DjCredentialsSecretArn, '']]

--- a/template.yaml
+++ b/template.yaml
@@ -91,6 +91,36 @@ Parameters:
     Description: >
       Optional `owner/repo` target for canary-filed issues, e.g.
       `WXYC/wxyc-canary`. Paired with GitHubTokenSsmParamName.
+  GhaRunnerTokenSsmParamName:
+    Type: String
+    Default: ''
+    AllowedPattern: '^(|/.+)$'
+    Description: >
+      Optional SSM Parameter Store name (SecureString) holding a
+      fine-scoped GitHub PAT with `admin:org → Self-hosted runners:
+      Read` (classic) or the fine-grained equivalent on the WXYC org.
+      Must begin with `/` (e.g. `/wxyc-canary/gha-runner-token`) so
+      the IAM policy ARN composes correctly. When set together with
+      `GhaRunnerId`, the `gha-runner-online` check polls
+      `GET /orgs/{org}/actions/runners/{id}` every 5 minutes and the
+      `wxyc-canary-check-failure` alarm fires after ~10 minutes of
+      sustained `status != "online"`. Leave empty to skip the probe
+      (operator gap, no alarm).
+  GhaRunnerOrg:
+    Type: String
+    Default: WXYC
+    Description: GitHub organization that owns the self-hosted runner.
+  GhaRunnerId:
+    Type: Number
+    Default: 0
+    Description: >
+      Numeric runner id assigned by GitHub at registration. Discover via
+      `gh api /orgs/WXYC/actions/runners --jq '.runners[] | select(.name=="wxyc-e2e-runner") | .id'`.
+      The id changes when the runner is replaced (re-registration), so
+      this parameter must be re-set after an instance swap — see
+      wxyc-shared `scripts/e2e-runner/README.md`. Leave at 0 to skip the
+      probe (the check downgrades to skipped, no alarm). The handler
+      forwards 0 verbatim; the check skips on "no runner id configured".
 
 Conditions:
   HasDjCredentials: !Not [!Equals [!Ref DjCredentialsSecretArn, '']]
@@ -99,6 +129,11 @@ Conditions:
   HasGitHubReporter: !And
     - !Not [!Equals [!Ref GitHubTokenSsmParamName, '']]
     - !Not [!Equals [!Ref GitHubIssuesRepo, '']]
+  HasGhaRunnerProbe: !And
+    - !Not [!Equals [!Ref GhaRunnerTokenSsmParamName, '']]
+    # !Ref on a Number parameter returns the value as a string ("0"), so the
+    # right-hand operand of !Equals must be the literal string "0", not 0.
+    - !Not [!Equals [!Ref GhaRunnerId, '0']]
 
 Resources:
   CanaryFunction:
@@ -124,6 +159,12 @@ Resources:
           CANARY_ENABLE_WRITE_PROBE: !Ref EnableWriteProbe
           CANARY_GITHUB_TOKEN_SSM_PARAM: !If [HasGitHubReporter, !Ref GitHubTokenSsmParamName, '']
           CANARY_GITHUB_ISSUES_REPO: !If [HasGitHubReporter, !Ref GitHubIssuesRepo, '']
+          CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: !If [HasGhaRunnerProbe, !Ref GhaRunnerTokenSsmParamName, '']
+          CANARY_GHA_RUNNER_ORG: !Ref GhaRunnerOrg
+          # Empty-string when the probe is disabled so the handler env loader
+          # sees a falsy value and the check downgrades to skipped (no alarm).
+          # When the probe is enabled, CFN stringifies the Number to e.g. "250".
+          CANARY_GHA_RUNNER_ID: !If [HasGhaRunnerProbe, !Ref GhaRunnerId, '']
       Policies:
         - Statement:
             - Effect: Allow
@@ -152,6 +193,13 @@ Resources:
               - Effect: Allow
                 Action: ssm:GetParameter
                 Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${GitHubTokenSsmParamName}
+          - !Ref AWS::NoValue
+        - !If
+          - HasGhaRunnerProbe
+          - Statement:
+              - Effect: Allow
+                Action: ssm:GetParameter
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${GhaRunnerTokenSsmParamName}
           - !Ref AWS::NoValue
       Events:
         Schedule:

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -83,10 +83,10 @@ describe('runCanary — anonymous-only configuration', () => {
     vi.unstubAllGlobals();
   });
 
-  it('passes the 2 truly-anonymous checks and skips the 7 conditional checks when no credentials are configured', async () => {
+  it('passes the 2 truly-anonymous checks and skips the 8 conditional checks when no credentials are configured', async () => {
     const outcomes = await runCanary(baseConfig);
 
-    expect(outcomes).toHaveLength(9);
+    expect(outcomes).toHaveLength(10);
     const byName = Object.fromEntries(outcomes.map((o) => [o.name, o]));
     expect(byName['backend-healthcheck'].status).toBe('pass');
     expect(byName['semantic-index-search'].status).toBe('pass');
@@ -101,6 +101,12 @@ describe('runCanary — anonymous-only configuration', () => {
     // `baseConfig` fixture leaves `lmlApiKey` undefined.
     expect(byName['lml-auth'].status).toBe('skipped');
     expect(byName['lml-auth'].message).toMatch(/no LML_API_KEY configured/);
+    // `gha-runner-online` skips when no GitHub PAT + runner id are
+    // configured (operator gap, mirrors lml-auth/DJ-creds). The probe
+    // exists to alarm when the EC2-hosted staging-gate runner stops
+    // checking in; the alarm only fires on `fail`, not `skipped`.
+    expect(byName['gha-runner-online'].status).toBe('skipped');
+    expect(byName['gha-runner-online'].message).toMatch(/no GitHub PAT|no runner id/);
   });
 });
 
@@ -544,6 +550,211 @@ describe('runCanary — lml-auth check (BS#1094 layer 1)', () => {
 });
 
 /**
+ * `gha-runner-online` is the liveness probe for the EC2-hosted self-hosted
+ * GitHub Actions runner that backs the staging-gate suites (Backend-Service,
+ * library-metadata-lookup, dj-site). Wired up as part of WXYC/wiki#80
+ * phase 1 acceptance: the bootstrap script and runbook (wxyc-shared#167)
+ * stand the runner up; this check pages on-call when it stops checking in.
+ *
+ * Probe shape: `GET /orgs/{org}/actions/runners/{id}` with a fine-scoped
+ * PAT. The API returns `{status: "online" | "offline", busy: bool, ...}`.
+ * The check passes on `status === "online"` and fails on anything else.
+ *
+ * The existing `wxyc-canary-check-failure` alarm (3 evaluations × 5 min,
+ * 2 datapoints-to-alarm) gives the spec's "≥10 minutes of `status != online`"
+ * window for free — no new alarm needed. Sustained outage breach: ~10 min.
+ *
+ * Skips with a meaningful reason when no PAT or no runner ID is configured
+ * (operator gap, mirrors `lml-auth` and DJ-creds). A PAT-resolution error
+ * (Secrets Manager / SSM IAM regression) fails the check rather than
+ * skipping — that's a real signal, not a config-gap.
+ *
+ * URL-substring matches use a synthetic host (`gha.example.test`) so the
+ * existing `setUpFetchMock` substring routing doesn't shadow other checks.
+ */
+describe('runCanary — gha-runner-online check (runner liveness probe, wiki#80 phase 1)', () => {
+  const RUNNER_ID = 250;
+  const ghaRunnerConfig: CanaryConfig = {
+    ...baseConfig,
+    ghaRunnerApiBase: 'https://gha.example.test',
+    ghaRunnerOrg: 'WXYC',
+    ghaRunnerId: RUNNER_ID,
+    ghaRunnerToken: 'fake-gha-pat',
+  };
+
+  /**
+   * Bearer-aware mock for the GH API: routes on the runners endpoint and
+   * returns the per-test status payload. The 2 truly-anonymous checks
+   * (`backend-healthcheck` + `semantic-index-search`) need their own
+   * stubs so the canary run produces the full happy-path-except-runner
+   * outcome shape — leaving them on 599 would make this test catch the
+   * unrelated anonymous-check failures instead of the runner one.
+   */
+  function setUpGhaApiMock(opts: { runnerStatus: number; runnerBody: unknown }) {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const respond = (resp: { status: number; body: unknown }) =>
+        new Response(typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body), {
+          status: resp.status,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      if (urlString.includes('/healthcheck')) return respond({ status: 200, body: { ok: true } });
+      if (urlString.includes('/graph/artists/search')) return respond({ status: 200, body: { results: [{ id: 1 }] } });
+      if (urlString.includes(`gha.example.test/orgs/WXYC/actions/runners/${RUNNER_ID}`)) {
+        // Headers contract: Authorization bearer + GH-version header. Captured
+        // for assertions in the dedicated test below; routed here so the
+        // body/status pin per-test.
+        void (init?.headers as Record<string, string> | undefined);
+        return respond({ status: opts.runnerStatus, body: opts.runnerBody });
+      }
+      return new Response(`unmatched mock for ${urlString}`, { status: 599 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes when the runner status is "online"', async () => {
+    setUpGhaApiMock({
+      runnerStatus: 200,
+      runnerBody: {
+        id: RUNNER_ID,
+        name: 'wxyc-e2e-runner',
+        status: 'online',
+        busy: false,
+        labels: [{ name: 'self-hosted' }, { name: 'e2e-runner' }],
+      },
+    });
+
+    const outcomes = await runCanary(ghaRunnerConfig);
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+    expect(runner.status).toBe('pass');
+  });
+
+  it('fails with an offline message when the runner status is "offline" (the spec\'s primary failure mode)', async () => {
+    setUpGhaApiMock({
+      runnerStatus: 200,
+      runnerBody: {
+        id: RUNNER_ID,
+        name: 'wxyc-e2e-runner',
+        // The runner has stopped polling GitHub — either the host is down,
+        // the systemd unit died, or the network egress to github.com is
+        // broken. All three need on-call attention. The alarm window
+        // (3 evals × 5 min, 2 to alarm) gives the spec's ≥10 min sustained
+        // breach.
+        status: 'offline',
+        busy: false,
+        labels: [{ name: 'self-hosted' }, { name: 'e2e-runner' }],
+      },
+    });
+
+    const outcomes = await runCanary(ghaRunnerConfig);
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('fail');
+    expect(runner.message).toMatch(/offline/);
+    expect(runner.message).toMatch(/wxyc-e2e-runner|250/);
+  });
+
+  it('fails with a clear message when the runner id no longer exists (404 — runner was replaced without updating the stack param)', async () => {
+    // When the operator replaces the EC2 host, the new runner gets a new
+    // id and the old one is removed from the org. If the CFN parameter
+    // `GhaRunnerId` is not updated to point at the new id, the probe 404s.
+    // Distinct failure class from "offline" so the on-call routes to the
+    // runbook entry on runner replacement, not "the runner died".
+    setUpGhaApiMock({
+      runnerStatus: 404,
+      runnerBody: { message: 'Not Found', documentation_url: 'https://docs.github.com/rest' },
+    });
+
+    const outcomes = await runCanary(ghaRunnerConfig);
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('fail');
+    expect(runner.message).toMatch(/404|not found/i);
+  });
+
+  it('fails with a distinct message when the PAT is revoked or unscoped (401/403)', async () => {
+    setUpGhaApiMock({
+      runnerStatus: 401,
+      runnerBody: { message: 'Bad credentials', documentation_url: 'https://docs.github.com/rest' },
+    });
+
+    const outcomes = await runCanary(ghaRunnerConfig);
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('fail');
+    // Operator routing: rotate the PAT, not "the runner is down".
+    expect(runner.message).toMatch(/401|credentials|PAT/i);
+  });
+
+  it('skips when no GitHub PAT is configured (operator gap, not regression)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+    });
+
+    const outcomes = await runCanary({
+      ...baseConfig,
+      ghaRunnerApiBase: 'https://gha.example.test',
+      ghaRunnerOrg: 'WXYC',
+      ghaRunnerId: RUNNER_ID,
+      // ghaRunnerToken intentionally omitted
+    });
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('skipped');
+    expect(runner.message).toMatch(/no GitHub PAT/);
+  });
+
+  it('skips when no runner id is configured (operator gap)', async () => {
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+    });
+
+    const outcomes = await runCanary({
+      ...baseConfig,
+      ghaRunnerApiBase: 'https://gha.example.test',
+      ghaRunnerOrg: 'WXYC',
+      ghaRunnerToken: 'fake-gha-pat',
+      // ghaRunnerId intentionally omitted
+    });
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('skipped');
+    expect(runner.message).toMatch(/no runner id/);
+  });
+
+  it('sends the PAT as Authorization: Bearer and targets /orgs/{org}/actions/runners/{id}', async () => {
+    const fetchMock = setUpGhaApiMock({
+      runnerStatus: 200,
+      runnerBody: { id: RUNNER_ID, status: 'online' },
+    });
+
+    await runCanary(ghaRunnerConfig);
+
+    const ghaCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('gha.example.test'));
+    expect(ghaCalls).toHaveLength(1);
+    const [url, init] = ghaCalls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://gha.example.test/orgs/WXYC/actions/runners/250');
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer fake-gha-pat');
+    // GitHub REST v3 prefers a versioned Accept header; the bare API
+    // version header is also recommended for forwards-compat. Pin both so
+    // a future GH-API rev that drops support for the unversioned default
+    // surfaces here as a test failure rather than a silent 404/406.
+    expect(headers.Accept).toMatch(/application\/vnd\.github/);
+    expect(headers['X-GitHub-Api-Version']).toBeDefined();
+  });
+});
+
+/**
  * Auth sign-in is the one place the canary retries (see signInDj). The
  * carve-out exists because a single 429 on sign-in cascades into 4 fail
  * outcomes plus a Lambda Errors alarm, even when the surfaces being
@@ -757,9 +968,9 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     const dimensioned = checkFailureData.filter((d) => d.Dimensions && d.Dimensions.length > 0);
     const dimensionless = checkFailureData.filter((d) => !d.Dimensions || d.Dimensions.length === 0);
 
-    // Nine checks, each contributes one dimensioned and one dimensionless datapoint.
-    expect(dimensioned).toHaveLength(9);
-    expect(dimensionless).toHaveLength(9);
+    // Ten checks, each contributes one dimensioned and one dimensionless datapoint.
+    expect(dimensioned).toHaveLength(10);
+    expect(dimensionless).toHaveLength(10);
     // Without an inducer, every value is 0 (passes + skips).
     expect(dimensioned.every((d) => d.Value === 0)).toBe(true);
     expect(dimensionless.every((d) => d.Value === 0)).toBe(true);
@@ -791,7 +1002,7 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     // isn't enough — `Statistic: Maximum` on the alarm needs at least one
     // `1` in the window, so this asserts the count of 1s explicitly.
     expect(dimensionless.filter((d) => d.Value === 1)).toHaveLength(1);
-    expect(dimensionless.filter((d) => d.Value === 0)).toHaveLength(8);
+    expect(dimensionless.filter((d) => d.Value === 0)).toHaveLength(9);
   });
 
   // `CheckSkipped` and `CheckLatency` are dashboard data, not alarm inputs.
@@ -812,8 +1023,8 @@ describe('publishMetrics — dimensioned + dimensionless emit-twice', () => {
     expect(metricData.filter((d) => d.MetricName === 'CheckSkipped' && isDimensionless(d))).toHaveLength(0);
     expect(metricData.filter((d) => d.MetricName === 'CheckLatency' && isDimensionless(d))).toHaveLength(0);
     // Sanity: the dimensioned series for each is present (one per check).
-    expect(metricData.filter((d) => d.MetricName === 'CheckSkipped')).toHaveLength(9);
-    expect(metricData.filter((d) => d.MetricName === 'CheckLatency')).toHaveLength(9);
+    expect(metricData.filter((d) => d.MetricName === 'CheckSkipped')).toHaveLength(10);
+    expect(metricData.filter((d) => d.MetricName === 'CheckLatency')).toHaveLength(10);
   });
 });
 

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -731,7 +731,7 @@ describe('runCanary — gha-runner-online check (runner liveness probe, wiki#80 
     expect(runner.message).toMatch(/no runner id/);
   });
 
-  it('sends the PAT as Authorization: Bearer and targets /orgs/{org}/actions/runners/{id}', async () => {
+  it('sends the PAT as Authorization: Bearer and targets /orgs/{org}/actions/runners/{id} via GET', async () => {
     const fetchMock = setUpGhaApiMock({
       runnerStatus: 200,
       runnerBody: { id: RUNNER_ID, status: 'online' },
@@ -743,6 +743,10 @@ describe('runCanary — gha-runner-online check (runner liveness probe, wiki#80 
     expect(ghaCalls).toHaveLength(1);
     const [url, init] = ghaCalls[0] as unknown as [string, RequestInit];
     expect(url).toBe('https://gha.example.test/orgs/WXYC/actions/runners/250');
+    // The check must use GET. The lml-auth check this one was modeled on uses
+    // POST; pin the method so a copy-paste refactor that swaps it doesn't
+    // silently start 404'ing in prod with a 'runner was likely replaced' page.
+    expect(String(init?.method ?? 'GET').toUpperCase()).toBe('GET');
     const headers = (init?.headers ?? {}) as Record<string, string>;
     expect(headers.Authorization).toBe('Bearer fake-gha-pat');
     // GitHub REST v3 prefers a versioned Accept header; the bare API
@@ -751,6 +755,186 @@ describe('runCanary — gha-runner-online check (runner liveness probe, wiki#80 
     // surfaces here as a test failure rather than a silent 404/406.
     expect(headers.Accept).toMatch(/application\/vnd\.github/);
     expect(headers['X-GitHub-Api-Version']).toBeDefined();
+  });
+
+  // Hardening tests addressing review feedback on the initial check shape.
+  // Each pins a known footgun the first pass either had or could grow into.
+
+  it('skips when ghaRunnerId is NaN (CANARY_GHA_RUNNER_ID was a non-numeric typo)', async () => {
+    // The env loader does `process.env.X ? Number(...) : undefined`. A typo
+    // like CANARY_GHA_RUNNER_ID=abc is truthy as a string; Number('abc') → NaN;
+    // typeof NaN === 'number'. Without an explicit isFinite/isInteger guard
+    // the check would URL-template NaN and 404, then misroute as 'runner was
+    // likely replaced'. Skip instead — operator-visible config error.
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+    });
+
+    const outcomes = await runCanary({
+      ...baseConfig,
+      ghaRunnerApiBase: 'https://gha.example.test',
+      ghaRunnerOrg: 'WXYC',
+      ghaRunnerToken: 'fake-gha-pat',
+      ghaRunnerId: Number.NaN,
+    });
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('skipped');
+    expect(runner.message).toMatch(/no runner id|invalid runner id/i);
+  });
+
+  it('skips when ghaRunnerId is 0 (the CFN-documented disabling sentinel) instead of probing /runners/0', async () => {
+    // The template treats GhaRunnerId=0 as the disabling sentinel and strips
+    // the env var to empty string. Belt-and-suspenders: the check itself
+    // must also treat 0 (and any non-positive integer) as the skip case so
+    // non-CFN deploy paths (local invoke, manual env override, future
+    // template refactor) cannot bypass the sentinel.
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+    });
+
+    const outcomes = await runCanary({
+      ...baseConfig,
+      ghaRunnerApiBase: 'https://gha.example.test',
+      ghaRunnerOrg: 'WXYC',
+      ghaRunnerToken: 'fake-gha-pat',
+      ghaRunnerId: 0,
+    });
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('skipped');
+    expect(runner.message).toMatch(/no runner id|invalid runner id/i);
+  });
+
+  it('fails with a distinct "GitHub rate-limited" message when 403 is a rate-limit, not a PAT-rejection', async () => {
+    // Primary-rate-limit 403s carry `X-RateLimit-Remaining: 0` and a body
+    // mentioning "rate limit". The check must NOT route this to "rotate the
+    // runner-liveness PAT" — that wastes operator time on a token that's
+    // perfectly valid. Distinct message + 'wait' framing instead.
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const respond = (resp: { status: number; body: unknown; headers?: Record<string, string> }) =>
+        new Response(typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body), {
+          status: resp.status,
+          headers: { 'Content-Type': 'application/json', ...(resp.headers ?? {}) },
+        });
+      if (urlString.includes('/healthcheck')) return respond({ status: 200, body: { ok: true } });
+      if (urlString.includes('/graph/artists/search')) return respond({ status: 200, body: { results: [{ id: 1 }] } });
+      if (urlString.includes(`gha.example.test/orgs/WXYC/actions/runners/${RUNNER_ID}`)) {
+        return respond({
+          status: 403,
+          body: {
+            message: 'API rate limit exceeded for user ID 12345.',
+            documentation_url: 'https://docs.github.com/rest',
+          },
+          headers: { 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1718000000' },
+        });
+      }
+      return new Response(`unmatched mock for ${urlString}`, { status: 599 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outcomes = await runCanary(ghaRunnerConfig);
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('fail');
+    expect(runner.message).toMatch(/rate limit/i);
+    // Must NOT mis-route to the PAT rotation runbook.
+    expect(runner.message).not.toMatch(/rotate/i);
+  });
+
+  it('fails with a distinct "GitHub degraded" message on 5xx (not the generic !ok branch)', async () => {
+    // The docstring on the check promises 5xx routes distinctly so the
+    // on-call goes to githubstatus.com, not the runner. Pin the contract.
+    setUpGhaApiMock({
+      runnerStatus: 503,
+      runnerBody: { message: 'Service Unavailable' },
+    });
+
+    const outcomes = await runCanary(ghaRunnerConfig);
+    const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+    expect(runner.status).toBe('fail');
+    expect(runner.message).toMatch(/GitHub.*degraded|githubstatus/i);
+    // Must NOT mis-route to the runner-replaced or PAT-rotation runbook.
+    expect(runner.message).not.toMatch(/replaced/i);
+    expect(runner.message).not.toMatch(/rotate/i);
+  });
+
+  it('uses the WXYC default for ghaRunnerOrg when the env value is an empty string (not just undefined)', async () => {
+    // `??` only catches nullish; an env-driven empty string for
+    // CANARY_GHA_RUNNER_ORG would let '' through and produce `/orgs//actions`.
+    // Pin that the default kicks in for both undefined and ''.
+    const fetchMock = setUpGhaApiMock({
+      runnerStatus: 200,
+      runnerBody: { id: RUNNER_ID, status: 'online' },
+    });
+
+    await runCanary({
+      ...ghaRunnerConfig,
+      ghaRunnerOrg: '',
+    });
+
+    const ghaCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('gha.example.test'));
+    expect(ghaCalls).toHaveLength(1);
+    const [url] = ghaCalls[0] as unknown as [string];
+    expect(url).toBe('https://gha.example.test/orgs/WXYC/actions/runners/250');
+  });
+
+  it('does not attempt SSM PAT resolution when no runner id is configured (half-configured probe must not page)', async () => {
+    // Half-configured-probe defense: a deploy that sets the SSM token param
+    // but forgets the runner-id parameter should NOT page on-call when SSM
+    // glitches transiently. The runner-id is the load-bearing gate; without
+    // it the probe wouldn't run anyway, so SSM resolution must be SKIPPED
+    // entirely. Pins both the resulting outcome AND that no SSM call was
+    // attempted — the latter is the actual contract; the former is the
+    // observable consequence.
+    ssmSendMock.mockClear();
+    setUpFetchMock({
+      '/healthcheck': { status: 200, body: { ok: true } },
+      '/graph/artists/search': { status: 200, body: { results: [{ id: 1 }] } },
+    });
+    process.env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM = '/wxyc-canary/gha-runner-token';
+
+    try {
+      const outcomes = await runCanary({
+        ...baseConfig,
+        ghaRunnerApiBase: 'https://gha.example.test',
+        ghaRunnerOrg: 'WXYC',
+        // ghaRunnerId intentionally omitted (probe not actually enabled)
+        // ghaRunnerToken intentionally omitted so resolution path would run
+        //   absent the gate
+      });
+      const runner = outcomes.find((o) => o.name === 'gha-runner-online')!;
+
+      expect(runner.status).toBe('skipped');
+      expect(runner.message).toMatch(/no runner id|invalid runner id/i);
+      // The actual contract: zero SSM calls when the runner-id is absent.
+      expect(ssmSendMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM;
+    }
+  });
+
+  it('normalizes a trailing slash on ghaRunnerApiBase so the URL has no double slash', async () => {
+    // Operator copy-paste hazard. GitHub today tolerates `//`; a path-strict
+    // proxy or future GH rev would 404 and misroute as 'runner replaced'.
+    const fetchMock = setUpGhaApiMock({
+      runnerStatus: 200,
+      runnerBody: { id: RUNNER_ID, status: 'online' },
+    });
+
+    await runCanary({
+      ...ghaRunnerConfig,
+      ghaRunnerApiBase: 'https://gha.example.test/',
+    });
+
+    const ghaCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('gha.example.test'));
+    expect(ghaCalls).toHaveLength(1);
+    const [url] = ghaCalls[0] as unknown as [string];
+    expect(url).toBe('https://gha.example.test/orgs/WXYC/actions/runners/250');
   });
 });
 
@@ -1668,6 +1852,11 @@ describe('handler — GitHub issue reporting dispatch', () => {
     delete process.env.CANARY_DJ_EMAIL;
     delete process.env.CANARY_DJ_PASSWORD;
     delete process.env.CANARY_DJ_SECRET_ARN;
+    // Defensive: the runner-liveness probe shares the SSM-mock dispatch
+    // with this block's `ssmSendMock.toHaveBeenCalledTimes(1)` assertion.
+    // A leaked CANARY_GHA_RUNNER_TOKEN_SSM_PARAM from CI shell or a prior
+    // test would cause a 2nd SSM call and fail this assertion opaquely.
+    delete process.env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM;
   });
 
   afterEach(() => {
@@ -1678,6 +1867,7 @@ describe('handler — GitHub issue reporting dispatch', () => {
     delete process.env.CANARY_PUBLISH_METRICS;
     delete process.env.CANARY_GITHUB_TOKEN_SSM_PARAM;
     delete process.env.CANARY_GITHUB_ISSUES_REPO;
+    delete process.env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM;
   });
 
   it('fetches the SSM PAT and invokes the reporter when both env vars are set', async () => {


### PR DESCRIPTION
Closes #39. Final piece of [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80) phase 1 acceptance — the runner bootstrap + runbook are in WXYC/wxyc-shared#167 + #168; this is the canary-side liveness probe.

## Summary

- New `gha-runner-online` check: `GET /orgs/{org}/actions/runners/{id}` every 5 min; fail on `status != "online"`.
- Reuses the existing `wxyc-canary-check-failure` alarm (3 × 5 min × 2-to-alarm = ~10 min sustained breach), matching the spec's "≥10 min `status != online`" window. No new alarm.
- Failure messages distinguish **offline** (host wedge), **404** (runner replaced without re-setting `GhaRunnerId`), and **401/403** (PAT rotation drift) so the on-call routes to the right runbook entry.
- Skip semantics mirror `lml-auth` / DJ-creds: missing config → `skipped` (alarm quiet), resolution error → `fail` (real signal).

## Implementation notes

- `CANARY_GHA_RUNNER_TOKEN` env (local/test) or `CANARY_GHA_RUNNER_TOKEN_SSM_PARAM` for SSM SecureString (prod). PAT lives under `/wxyc-canary/*` so it shares the rotation cadence + IAM grant pattern with the existing GitHub-issues reporter PAT.
- Three new SAM parameters (`GhaRunnerTokenSsmParamName`, `GhaRunnerOrg`, `GhaRunnerId`) with a conditional `ssm:GetParameter` grant scoped to the PAT path. Setting `GhaRunnerId=0` or empty `GhaRunnerTokenSsmParamName` disables the probe (check downgrades to `skipped`, no alarm, no IAM grant).
- README adds: probe setup section (PAT scope → SSM put-parameter → runner-id discovery → deploy params), and runbook entry for the new check's three failure modes.

## Test plan

- [x] Vitest: 52/52 (added 7 new tests covering pass, offline, 404, 401, missing-PAT skip, missing-id skip, request shape).
- [x] `npm run typecheck` clean.
- [x] `npm run format:check` clean.
- [x] `npm run build` clean.
- [ ] Post-merge: operator (Jake) sets up the SSM PAT, redeploys with the three new parameters, and confirms the `gha-runner-online` `CheckFailure` series reads 0 within 5 min.

## Related

- Parent epic: WXYC/wiki#80
- Runner topology + replacement runbook: WXYC/wxyc-shared `scripts/e2e-runner/README.md` (WXYC/wxyc-shared#167, #168)