### PR TITLE
Wire runner-liveness SAM params through deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,16 @@ jobs:
       - name: SAM build
         run: sam build
       - name: SAM deploy
+        # `GhaRunnerTokenSsmParamName` defaults empty and `GhaRunnerId` defaults
+        # '0' so the runner-liveness probe stays disabled until the SSM PAT
+        # exists in the canary's AWS account AND the corresponding GH Action
+        # variables (`GHA_RUNNER_TOKEN_SSM_PARAM_NAME`, `GHA_RUNNER_ID`) are
+        # set. See `scripts/e2e-runner/README.md` (in wxyc-shared) for the
+        # runner topology and the README in this repo's "Runner liveness probe"
+        # section for the SSM PAT setup. Sequencing intent: probe ships
+        # disabled, operator opts in by creating the SSM PAT then flipping
+        # the GH vars, then a workflow_dispatch run enables the probe
+        # atomically without an alarm window.
         run: |
           sam deploy \
             --no-confirm-changeset \
@@ -60,4 +70,7 @@ jobs:
               LmlUrl=${{ vars.LML_URL || 'https://library-metadata-lookup-production.up.railway.app' }} \
               LmlApiKeySecretArn=${{ secrets.LML_API_KEY_SECRET_ARN }} \
               DjCredentialsSecretArn=${{ secrets.DJ_CREDENTIALS_SECRET_ARN }} \
-              AlertEmail=${{ vars.ALERT_EMAIL }}
+              AlertEmail=${{ vars.ALERT_EMAIL }} \
+              GhaRunnerTokenSsmParamName=${{ vars.GHA_RUNNER_TOKEN_SSM_PARAM_NAME }} \
+              GhaRunnerOrg=${{ vars.GHA_RUNNER_ORG || 'WXYC' }} \
+              GhaRunnerId=${{ vars.GHA_RUNNER_ID || '0' }}

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ Required GitHub variables (override defaults if needed):
 
 - `BACKEND_URL`, `AUTH_URL`, `SEMANTIC_INDEX_URL`, `ALERT_EMAIL`
 
+Optional GitHub variables for the runner-liveness probe (when all three are set the next deploy enables `gha-runner-online`; leave unset to keep it skipped):
+
+- `GHA_RUNNER_TOKEN_SSM_PARAM_NAME` — SSM SecureString path that the operator has populated, e.g. `/wxyc-canary/gha-runner-token`. Defaults empty → probe disabled.
+- `GHA_RUNNER_ORG` — defaults to `WXYC`.
+- `GHA_RUNNER_ID` — numeric runner id from `gh api /orgs/WXYC/actions/runners`. Defaults to `0` → probe disabled.
+
 ## Operating runbook
 
 ### Alarm fires: `wxyc-canary-check-failure`


### PR DESCRIPTION
Follow-up to #40 ([gha-runner-online](https://github.com/WXYC/wxyc-canary/pull/40)). Threads the three new SAM parameters (`GhaRunnerTokenSsmParamName`, `GhaRunnerOrg`, `GhaRunnerId`) through `.github/workflows/deploy.yml`, sourced from optional GH Action variables.

## Sequencing

Defaults keep the probe disabled — `GhaRunnerTokenSsmParamName` defaults empty, `GhaRunnerId` defaults `'0'` — so the existing `HasGhaRunnerProbe` condition stays false on first deploy after merge. No IAM grant, no env vars, check skips, no alarm window.

The operator enables the probe by:

1. Creating the SSM SecureString PAT in the canary's AWS account (`/wxyc-canary/gha-runner-token` per convention).
2. Setting the three GH Action variables: `GHA_RUNNER_TOKEN_SSM_PARAM_NAME`, `GHA_RUNNER_ORG`, `GHA_RUNNER_ID`.
3. Running `gh workflow run "Deploy WXYC Canary"` to deploy with the now-populated vars — probe enables atomically.

## Test plan

- [x] `prettier --check` clean on both files.
- [ ] Auto-deploy runs on merge — `sam deploy` succeeds with the new (empty/0) param overrides; no resource changes since the conditional gate stays false.