### PR TITLE
Add wxyc-canary check CLI shim for staging-gate use

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ export CANARY_PUBLISH_METRICS=false
 # Optional, exercises DJ-auth checks:
 export CANARY_DJ_EMAIL=canary@wxyc.org
 export CANARY_DJ_PASSWORD=...
-export CANARY_LOCAL=true
 npm run local
 ```
 
@@ -77,13 +76,14 @@ wxyc-canary check \
 
 Credentials come from environment variables only (flags would leak into shell history and CI logs):
 
-| Env var              | Purpose                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `CANARY_DJ_EMAIL`    | DJ login for auth-protected checks. Without it, those checks `skipped` (not fail).                                           |
-| `CANARY_DJ_PASSWORD` | Pairs with `CANARY_DJ_EMAIL`.                                                                                                |
-| `CANARY_LML_API_KEY` | LML bearer for the `lml-auth` check. Without it, the check `skipped`.                                                        |
-| `CANARY_ORIGIN_URL`  | Sent as `Origin:` on better-auth calls. Must match a `BETTER_AUTH_TRUSTED_ORIGINS` value. Defaults to `https://dj.wxyc.org`. |
-| `CANARY_TIMEOUT_MS`  | Per-check fetch timeout. Defaults to 8000.                                                                                   |
+| Env var              | Purpose                                                                                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CANARY_DJ_EMAIL`    | DJ login email. Pairs with `CANARY_DJ_PASSWORD`; both must be set together or both unset (XOR is rejected as exit 2). When both unset, DJ-auth checks `skipped` (not fail). |
+| `CANARY_DJ_PASSWORD` | DJ login password. See above.                                                                                                                                               |
+| `CANARY_LML_API_KEY` | LML bearer for the `lml-auth` check. Without it, the check `skipped`.                                                                                                       |
+| `CANARY_ORIGIN_URL`  | Sent as `Origin:` on better-auth calls. Must match a `BETTER_AUTH_TRUSTED_ORIGINS` value. Defaults to `https://dj.wxyc.org`.                                                |
+
+`*_SECRET_ARN` and `*_SSM_PARAM` env vars used by the Lambda are **not** read by the CLI. The CLI passes a sanitized env to `runCanary` so an operator with those vars exported in their shell cannot accidentally trigger AWS-SDK calls from a CLI invocation — verified by `test/cli-aws-isolation.test.ts`.
 
 ### Suites
 
@@ -95,7 +95,7 @@ Lambda-only checks (`gha-runner-online`, `enrichment-quality`, `semantic-index-s
 
 ### Output
 
-Stdout is one JSON line, parseable by `jq`:
+Stdout is exactly one JSON line, parseable by `jq`. The outcome shape is projected to the documented fields below — fields like `metrics` that the Lambda may attach internally are **not** emitted by the CLI, even when a future check returns them:
 
 ```json
 {
@@ -112,6 +112,8 @@ Stdout is one JSON line, parseable by `jq`:
   ]
 }
 ```
+
+`outcomes[i].message` is present only when `status !== 'pass'`. Control characters in messages are stripped before they reach stderr to neutralize log-injection attempts via probed-endpoint response bodies.
 
 Stderr is a human-readable summary headline plus a line for every non-pass outcome — readable from a GHA workflow log without piping stdout through `jq`.
 
@@ -176,7 +178,7 @@ sam deploy --guided \
     EnableWriteProbe=false
 ```
 
-Leave `EnableWriteProbe=false` for the first deploy. Once the DJ test account is provisioned, the `wxyc-canary-enrichment-lag` alarm is wired to the right SNS subscriber, and you've verified cleanup behaviour in a manual local run (`CANARY_ENABLE_WRITE_PROBE=true CANARY_LOCAL=true npm run local` against a non-prod environment), redeploy with `EnableWriteProbe=true` to turn the write canary on.
+Leave `EnableWriteProbe=false` for the first deploy. Once the DJ test account is provisioned, the `wxyc-canary-enrichment-lag` alarm is wired to the right SNS subscriber, and you've verified cleanup behaviour in a manual local run (`CANARY_ENABLE_WRITE_PROBE=true npm run local` against a non-prod environment), redeploy with `EnableWriteProbe=true` to turn the write canary on.
 
 ### Verifying the write canary in staging
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,94 @@ export CANARY_LOCAL=true
 npm run local
 ```
 
+## CLI for staging-gate consumers
+
+The same check code that runs in the Lambda is also exposed as a `wxyc-canary` CLI for the [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80) staging-gate workflows (wxyc-shared `bs-lml-gate.yml`, dj-site `staging-gate.yml`). The CLI runs probes against arbitrary BS/LML URLs — staging, preview, prod — and reports exit codes a GHA workflow can branch on.
+
+### Invocation
+
+```bash
+wxyc-canary check \
+  --base-url=https://bs-staging.wxyc.org \
+  --auth-url=https://bs-staging.wxyc.org/auth \
+  --lml-url=https://library-metadata-lookup-staging.up.railway.app \
+  --suite=smoke
+```
+
+Credentials come from environment variables only (flags would leak into shell history and CI logs):
+
+| Env var              | Purpose                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `CANARY_DJ_EMAIL`    | DJ login for auth-protected checks. Without it, those checks `skipped` (not fail).                                           |
+| `CANARY_DJ_PASSWORD` | Pairs with `CANARY_DJ_EMAIL`.                                                                                                |
+| `CANARY_LML_API_KEY` | LML bearer for the `lml-auth` check. Without it, the check `skipped`.                                                        |
+| `CANARY_ORIGIN_URL`  | Sent as `Origin:` on better-auth calls. Must match a `BETTER_AUTH_TRUSTED_ORIGINS` value. Defaults to `https://dj.wxyc.org`. |
+| `CANARY_TIMEOUT_MS`  | Per-check fetch timeout. Defaults to 8000.                                                                                   |
+
+### Suites
+
+| Suite   | Checks included                                                                                     | Use case                                  |
+| ------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `smoke` | `backend-healthcheck`, `proxy-library-search`, `dj-library-search`, `dj-flowsheet-read`, `lml-auth` | BS+LML staging-gate, dj-site gate-vs-prod |
+
+Lambda-only checks (`gha-runner-online`, `enrichment-quality`, `semantic-index-search`, `dj-rotation`, `dj-rotation-picker`) are unreachable from the CLI by design — they're either prod-only operator concerns, writes, or out-of-scope services. Add a new suite by extending the `Suite` union in `src/types.ts`, appending to `VALID_SUITES` in `src/checks.ts`, and tagging the relevant checks with `suites: [...]`.
+
+### Output
+
+Stdout is one JSON line, parseable by `jq`:
+
+```json
+{
+  "suite": "smoke",
+  "passed": 4,
+  "failed": 0,
+  "skipped": 1,
+  "outcomes": [
+    { "name": "backend-healthcheck", "status": "pass", "latencyMs": 12 },
+    { "name": "proxy-library-search", "status": "pass", "latencyMs": 45 },
+    { "name": "dj-library-search", "status": "pass", "latencyMs": 67 },
+    { "name": "dj-flowsheet-read", "status": "pass", "latencyMs": 22 },
+    { "name": "lml-auth", "status": "skipped", "latencyMs": 0, "message": "no LML_API_KEY configured" }
+  ]
+}
+```
+
+Stderr is a human-readable summary headline plus a line for every non-pass outcome — readable from a GHA workflow log without piping stdout through `jq`.
+
+### Exit codes
+
+| Code | Meaning                                                                                                                                                                                          |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0`  | Every check returned `pass` or `skipped`.                                                                                                                                                        |
+| `1`  | At least one check returned `fail`. Stdout JSON names the failing check(s); stderr lists them with messages.                                                                                     |
+| `2`  | Invocation error (unknown subcommand, missing required flag, unknown flag, unknown suite). Distinct from `1` so the gate workflow can tell "your config is wrong" from "your service is broken". |
+
+### Distribution (e2e-runner consumption)
+
+The CLI is consumed by cloning the repo onto the e2e-runner host during bootstrap:
+
+```bash
+sudo mkdir -p /opt/wxyc-canary
+sudo chown $USER /opt/wxyc-canary
+git clone https://github.com/WXYC/wxyc-canary.git /opt/wxyc-canary
+cd /opt/wxyc-canary
+git checkout <pinned-sha>
+npm ci
+npm run build:cli
+```
+
+Workflows then invoke it as:
+
+```bash
+node /opt/wxyc-canary/dist/cli.js check --base-url=... --auth-url=... --lml-url=... --suite=smoke
+```
+
+Pinning to a SHA gives consumers an explicit upgrade lever — bump the SHA in the runner-bootstrap script to pick up a non-breaking change; a breaking change forces re-running the bootstrap. The full update procedure lives in the staging-gate runbook ([WXYC/wiki#81](https://github.com/WXYC/wiki/issues/81)).
+
+### Side-effect contract
+
+The CLI never instantiates the AWS SDK. It hard-codes `publishMetrics: false`, doesn't read any `*_SSM_PARAM` or `*_SECRET_ARN` env vars, and never reaches the GitHub-issue-mirroring code path. The Lambda's runner-liveness probe (`gha-runner-online`) and write canary (`enrichment-quality`) stay invisible to the CLI even when a future operator sets the corresponding env vars — they're not in any suite.
+
 ## Deploying
 
 ### One-time setup

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ wxyc-canary check \
 
 Credentials come from environment variables only (flags would leak into shell history and CI logs):
 
-| Env var              | Purpose                                                                                                                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CANARY_DJ_EMAIL`    | DJ login email. Pairs with `CANARY_DJ_PASSWORD`; both must be set together or both unset (XOR is rejected as exit 2). When both unset, DJ-auth checks `skipped` (not fail). |
-| `CANARY_DJ_PASSWORD` | DJ login password. See above.                                                                                                                                               |
-| `CANARY_LML_API_KEY` | LML bearer for the `lml-auth` check. Without it, the check `skipped`.                                                                                                       |
-| `CANARY_ORIGIN_URL`  | Sent as `Origin:` on better-auth calls. Must match a `BETTER_AUTH_TRUSTED_ORIGINS` value. Defaults to `https://dj.wxyc.org`.                                                |
+| Env var              | Purpose                                                                                                                                                                                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CANARY_DJ_EMAIL`    | DJ login email. Pairs with `CANARY_DJ_PASSWORD`; when the selected suite includes a DJ-auth check, both must be set together or both unset (XOR is rejected as exit 2). Whitespace-only values are treated as unset. When both unset, DJ-auth checks `skipped` (not fail). |
+| `CANARY_DJ_PASSWORD` | DJ login password. See above.                                                                                                                                                                                                                                              |
+| `CANARY_LML_API_KEY` | LML bearer for the `lml-auth` check. Without it, the check `skipped`.                                                                                                                                                                                                      |
+| `CANARY_ORIGIN_URL`  | Sent as `Origin:` on better-auth calls. Must match a `BETTER_AUTH_TRUSTED_ORIGINS` value. Defaults to `https://dj.wxyc.org`.                                                                                                                                               |
 
 `*_SECRET_ARN` and `*_SSM_PARAM` env vars used by the Lambda are **not** read by the CLI. The CLI passes a sanitized env to `runCanary` so an operator with those vars exported in their shell cannot accidentally trigger AWS-SDK calls from a CLI invocation — verified by `test/cli-aws-isolation.test.ts`.
 
@@ -113,7 +113,7 @@ Stdout is exactly one JSON line, parseable by `jq`. The outcome shape is project
 }
 ```
 
-`outcomes[i].message` is present only when `status !== 'pass'`. Control characters in messages are stripped before they reach stderr to neutralize log-injection attempts via probed-endpoint response bodies.
+`outcomes[i].message` is present only when `status !== 'pass'`. Control characters AND Unicode line separators (U+2028, U+2029, U+0085) in messages are stripped before they reach stderr to neutralize log-injection attempts via probed-endpoint response bodies. The same sanitizer is applied to the fatal-error path (any uncaught throw out of `runCli` runs through `sanitizeForLog` before being written to stderr) so a thrown Error whose message interpolates a server response body cannot bypass the defense.
 
 Stderr is a human-readable summary headline plus a line for every non-pass outcome — readable from a GHA workflow log without piping stdout through `jq`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,15 @@
       "name": "wxyc-canary",
       "version": "0.1.0",
       "license": "ISC",
-      "devDependencies": {
+      "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.700.0",
         "@aws-sdk/client-secrets-manager": "^3.700.0",
-        "@aws-sdk/client-ssm": "^3.1056.0",
+        "@aws-sdk/client-ssm": "^3.1056.0"
+      },
+      "bin": {
+        "wxyc-canary": "dist/cli.js"
+      },
+      "devDependencies": {
         "@types/aws-lambda": "^8.10.146",
         "@types/node": "^22.10.0",
         "esbuild": "^0.24.0",
@@ -29,7 +34,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -44,7 +48,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -60,7 +63,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -73,7 +75,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -87,7 +88,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -101,7 +101,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -116,7 +115,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -126,7 +124,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -138,7 +135,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -151,7 +147,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -165,7 +160,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -179,7 +173,6 @@
       "version": "3.1040.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1040.0.tgz",
       "integrity": "sha512-oB2Dcsu686+Q1kG8XWVN1DAEeylRnLgqU6An0Krje9nxV7cccxRgHpL5TYCaOJf7EaxQEshnqr32u9ERJkf37g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -232,7 +225,6 @@
       "version": "3.1040.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1040.0.tgz",
       "integrity": "sha512-qszI/6MUy57rSqA2eSN3jbdjU1RFUDkayw7HbSX02jRmP896mSssWM0BC+mwYXuY7d3s1QntxmMKiNwXEXRdWg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -283,7 +275,6 @@
       "version": "3.1056.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1056.0.tgz",
       "integrity": "sha512-S367Brp+IyAc76US26MlOgYXvcMJMqKQi1gR4GcUI5K7NgG/f3AsICXV9Hg+KjqurSyyb8B2w8SgDJ20VT/bNg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -305,7 +296,6 @@
       "version": "3.974.15",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
       "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
@@ -325,7 +315,6 @@
       "version": "3.972.41",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
       "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -342,7 +331,6 @@
       "version": "3.972.43",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
       "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -361,7 +349,6 @@
       "version": "3.972.45",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.45.tgz",
       "integrity": "sha512-sJe5ZWibO4s7RWjFQ8Zol76KxoJcIYyEZH1/wxQSBMSIAAxzaJ8cS/ITAaIHWUQvDKQdt18+cJAHKWB7n1Jmrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -386,7 +373,6 @@
       "version": "3.972.45",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
       "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -404,7 +390,6 @@
       "version": "3.972.46",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.46.tgz",
       "integrity": "sha512-cS4w0jzDRb1jOlkiJS3y80OxddHzkky/MN9k3NYs5jganNKVLjF0lpvjlwS118oGMr3cdAfOlVdo8gLurTSE7w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.41",
@@ -427,7 +412,6 @@
       "version": "3.972.41",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
       "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -444,7 +428,6 @@
       "version": "3.972.45",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
       "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -463,7 +446,6 @@
       "version": "3.972.45",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
       "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -481,7 +463,6 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
       "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -497,7 +478,6 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
       "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -512,7 +492,6 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
       "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -529,7 +508,6 @@
       "version": "3.972.37",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.37.tgz",
       "integrity": "sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.7",
@@ -549,7 +527,6 @@
       "version": "3.997.13",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
       "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -571,7 +548,6 @@
       "version": "3.972.13",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
       "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -588,7 +564,6 @@
       "version": "3.996.30",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
       "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.9",
@@ -604,7 +579,6 @@
       "version": "3.1056.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
       "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.15",
@@ -622,7 +596,6 @@
       "version": "3.973.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
       "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.2",
@@ -636,7 +609,6 @@
       "version": "3.996.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
       "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -653,7 +625,6 @@
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
       "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -666,7 +637,6 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
       "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -679,7 +649,6 @@
       "version": "3.973.23",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.23.tgz",
       "integrity": "sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "^3.972.37",
@@ -705,7 +674,6 @@
       "version": "3.972.26",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
       "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.2",
@@ -720,7 +688,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1179,7 +1146,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
       "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1581,7 +1547,6 @@
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
       "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
@@ -1599,7 +1564,6 @@
       "version": "3.24.5",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
       "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -1614,7 +1578,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.5.tgz",
       "integrity": "sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.5",
@@ -1629,7 +1592,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
       "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.5",
@@ -1644,7 +1606,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
       "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1660,7 +1621,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
       "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1674,7 +1634,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
       "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1687,7 +1646,6 @@
       "version": "4.3.46",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.46.tgz",
       "integrity": "sha512-9f4AZ5dKqKRmO49MPhOoxFoQBLfBgxE9YKG8bQ6lsW9xk+Bn8rkfGlpW8OYlvhuarN+8mja9PjhEudFiR8wGFQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -1709,7 +1667,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
       "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -1724,7 +1681,6 @@
       "version": "4.4.32",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
       "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -1744,7 +1700,6 @@
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
       "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -1766,7 +1721,6 @@
       "version": "4.2.20",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
       "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -1782,7 +1736,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
       "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1796,7 +1749,6 @@
       "version": "4.3.14",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
       "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
@@ -1812,7 +1764,6 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
       "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.5",
@@ -1827,7 +1778,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
       "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1841,7 +1791,6 @@
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
       "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1855,7 +1804,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
       "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1869,7 +1817,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
       "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1"
@@ -1882,7 +1829,6 @@
       "version": "4.4.9",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
       "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -1896,7 +1842,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
       "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.5",
@@ -1911,7 +1856,6 @@
       "version": "4.12.13",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
       "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -1930,7 +1874,6 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
       "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1943,7 +1886,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
       "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.14",
@@ -1958,7 +1900,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
       "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -1973,7 +1914,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
       "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1986,7 +1926,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
       "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1999,7 +1938,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
       "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
@@ -2013,7 +1951,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
       "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2026,7 +1963,6 @@
       "version": "4.3.49",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
       "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
@@ -2042,7 +1978,6 @@
       "version": "4.2.54",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
       "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.17",
@@ -2061,7 +1996,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
       "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
@@ -2076,7 +2010,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
       "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2089,7 +2022,6 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
       "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2103,7 +2035,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
       "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.3.1",
@@ -2118,7 +2049,6 @@
       "version": "4.5.25",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
       "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -2138,7 +2068,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
       "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -2152,7 +2081,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
       "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2166,7 +2094,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
       "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2326,7 +2253,6 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cac": {
@@ -2466,7 +2392,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2483,7 +2408,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2505,7 +2429,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
       "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fsevents": {
@@ -2583,7 +2506,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2754,7 +2676,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
       "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2811,7 +2732,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -3922,7 +3842,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "local": "tsx src/handler.ts",
+    "local": "tsx src/handler-local.ts",
     "local:cli": "tsx src/cli-entry.ts"
   },
   "keywords": [
@@ -30,10 +30,12 @@
     "lambda"
   ],
   "license": "ISC",
-  "devDependencies": {
+  "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.700.0",
     "@aws-sdk/client-secrets-manager": "^3.700.0",
-    "@aws-sdk/client-ssm": "^3.1056.0",
+    "@aws-sdk/client-ssm": "^3.1056.0"
+  },
+  "devDependencies": {
     "@types/aws-lambda": "^8.10.146",
     "@types/node": "^22.10.0",
     "esbuild": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -5,17 +5,23 @@
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
+  "bin": {
+    "wxyc-canary": "dist/cli.js"
+  },
   "engines": {
     "node": "24.x"
   },
   "scripts": {
-    "build": "esbuild src/handler.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/handler.js --external:aws-sdk",
+    "build": "npm run build:lambda && npm run build:cli",
+    "build:lambda": "esbuild src/handler.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/handler.js --external:aws-sdk",
+    "build:cli": "esbuild src/cli-entry.ts --bundle --platform=node --target=node24 --format=esm --outfile=dist/cli.js --banner:js='#!/usr/bin/env node' --external:@aws-sdk/* --external:@smithy/* && chmod +x dist/cli.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "local": "tsx src/handler.ts"
+    "local": "tsx src/handler.ts",
+    "local:cli": "tsx src/cli-entry.ts"
   },
   "keywords": [
     "wxyc",

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -488,6 +488,23 @@ export const checks: readonly Check[] = [
 export const VALID_SUITES = ['smoke'] as const satisfies readonly Suite[];
 
 /**
+ * Exhaustiveness check: the type below errors at compile time when a
+ * member of the `Suite` union is missing from `VALID_SUITES`. The
+ * `satisfies` clause above enforces the other direction (every entry
+ * in `VALID_SUITES` is a valid `Suite`); together they pin the two in
+ * lock-step. Without this, extending `Suite = 'smoke' | 'dj-site'`
+ * without bumping `VALID_SUITES` would type-check cleanly and the CLI
+ * would reject `--suite=dj-site` as unknown at runtime.
+ */
+type _ExhaustivenessCheck =
+  Exclude<Suite, (typeof VALID_SUITES)[number]> extends never
+    ? true
+    : 'Suite union has a member missing from VALID_SUITES';
+const _exhaustivenessCheck: _ExhaustivenessCheck = true;
+// Silence "declared but never read" — the assignment site is the assertion.
+void _exhaustivenessCheck;
+
+/**
  * Return the checks tagged with the given suite. Untagged checks (no
  * `suites` field) are unreachable from the CLI by design — they're the
  * Lambda-only checks (prod-only operator concerns like `gha-runner-online`,

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,6 +1,6 @@
 import { canaryFetch, type FetchResult } from './client.js';
 import { runEnrichmentCheck } from './enrichment-check.js';
-import type { Check, CheckResult } from './types.js';
+import type { Check, CheckResult, Suite } from './types.js';
 
 /**
  * The canonical artist used for read-side probes. Stereolab has been on
@@ -15,6 +15,7 @@ const healthcheck: Check = {
   name: 'backend-healthcheck',
   description: 'GET /healthcheck on Backend-Service',
   requiresAuth: false,
+  suites: ['smoke'],
   run: async (ctx) => {
     const r = await canaryFetch(`${ctx.backendUrl}/healthcheck`);
     if (!r.ok) throw new Error(`expected 2xx, got ${r.status}: ${r.rawText.slice(0, 200)}`);
@@ -32,6 +33,7 @@ const proxyLibrarySearch: Check = {
   name: 'proxy-library-search',
   description: 'GET /proxy/library/search — exercises BS → LML',
   requiresAuth: true,
+  suites: ['smoke'],
   run: async (ctx) => {
     if (!ctx.djBearerToken) throw new Error('DJ bearer token missing');
     const r = await canaryFetch(
@@ -79,6 +81,7 @@ const djLibrarySearch: Check = {
   name: 'dj-library-search',
   description: 'GET /library/?artist_name=... as DJ — catches catalog-search 503',
   requiresAuth: true,
+  suites: ['smoke'],
   run: async (ctx) => {
     if (!ctx.djBearerToken) throw new Error('DJ bearer token missing');
     const r = await canaryFetch(`${ctx.backendUrl}/library/?artist_name=${encodeURIComponent(PROBE_ARTIST)}&n=5`, {
@@ -104,6 +107,7 @@ const djFlowsheetRead: Check = {
   name: 'dj-flowsheet-read',
   description: 'GET /flowsheet?n=5 as DJ',
   requiresAuth: true,
+  suites: ['smoke'],
   run: async (ctx) => {
     if (!ctx.djBearerToken) throw new Error('DJ bearer token missing');
     const r = await canaryFetch(`${ctx.backendUrl}/flowsheet?n=5`, {
@@ -236,6 +240,7 @@ const lmlAuth: Check = {
   description:
     'POST /api/v1/lookup directly to LML with LML_API_KEY — catches BS#1094 bearer rotation drift + LML_REQUIRE_AUTH=false',
   requiresAuth: false,
+  suites: ['smoke'],
   run: async (ctx): Promise<CheckResult | void> => {
     if (!ctx.lmlApiKey) {
       return { skipped: true, skipReason: 'no LML_API_KEY configured' };
@@ -469,6 +474,30 @@ export const checks: readonly Check[] = [
   ghaRunnerOnline,
   enrichmentQuality,
 ];
+
+/**
+ * The complete set of suite tags accepted by the CLI's `--suite` flag. The
+ * `satisfies` clause forces a compile error if a string here drifts from
+ * the `Suite` union, and the `as const` makes the array readable as a
+ * literal type so the CLI can list valid values in error messages.
+ *
+ * Add a new suite by extending the `Suite` union in types.ts, appending
+ * here, and tagging the relevant checks. The CLI's `--suite` validator
+ * reads this constant — no third place to update.
+ */
+export const VALID_SUITES = ['smoke'] as const satisfies readonly Suite[];
+
+/**
+ * Return the checks tagged with the given suite. Untagged checks (no
+ * `suites` field) are unreachable from the CLI by design — they're the
+ * Lambda-only checks (prod-only operator concerns like `gha-runner-online`,
+ * writes like `enrichment-quality`, scope-mismatched probes like
+ * `semantic-index-search` that hits a different service). The Lambda
+ * continues to consume the full `checks` array directly.
+ */
+export function checksForSuite(suite: Suite): readonly Check[] {
+  return checks.filter((c) => c.suites?.includes(suite));
+}
 
 /**
  * Parse a `Retry-After` header in seconds form (the date form is rare on

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -2,8 +2,7 @@
 // dist/cli.js, so this file is the executable. All testable logic lives
 // in `./cli.js`'s `runCli`; this entry is a thin IO wiring shell so the
 // test suite can import `runCli` directly without firing process.exit.
-import { runCli } from './cli.js';
-import { sanitizeForLog } from './cli.js';
+import { runCli, sanitizeForLog } from './cli.js';
 
 /**
  * Format a thrown value for the fatal-error stderr line. `err` is typed
@@ -54,9 +53,21 @@ async function exitAfterDrain(code: number): Promise<never> {
   // Trigger empty writes whose callbacks fire after the previously
   // queued bytes have flushed to the underlying transport. If the
   // streams are already drained, the callback fires on the next tick.
-  await Promise.all([
-    new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
-    new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+  //
+  // Race against a 500ms timeout — if a stream is in a wedged state
+  // (e.g. EPIPE after `wxyc-canary check | head -1`, where the reader
+  // hangs up mid-write), the drain callback can sit on the writable's
+  // pending queue indefinitely. The timeout caps total exit latency
+  // so a stuck pipe doesn't leave the CLI hanging in a GHA workflow.
+  // 500ms is comfortably longer than any local pipe drain takes; if
+  // we hit it the bytes are lost anyway, and exiting promptly is more
+  // valuable than blocking forever.
+  await Promise.race([
+    Promise.all([
+      new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
+      new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+    ]),
+    new Promise<void>((resolve) => setTimeout(resolve, 500).unref()),
   ]);
   process.exit(code);
 }

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -4,13 +4,56 @@
 // test suite can import `runCli` directly without firing process.exit.
 import { runCli } from './cli.js';
 
+/**
+ * Format a thrown value for the fatal-error stderr line. `err` is typed
+ * `unknown` because library code may `throw 'string'` / `throw {code:'X'}`
+ * / `throw undefined`. The early `err instanceof Error` branch keeps the
+ * stack trace; the else branch coerces with care so we never print a bare
+ * `undefined` or `[object Object]`.
+ */
+function formatFatal(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? err.message ?? String(err);
+  }
+  if (err === undefined) return 'undefined (no Error object thrown)';
+  if (err === null) return 'null (no Error object thrown)';
+  if (typeof err === 'object') {
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return Object.prototype.toString.call(err);
+    }
+  }
+  return String(err);
+}
+
 runCli(process.argv.slice(2), process.env, {
-  stdout: (s) => process.stdout.write(s),
-  stderr: (s) => process.stderr.write(s),
+  // Wrap stdout/stderr writes so the entry can await pipe drainage before
+  // exiting. `process.stdout.write` is async when stdout is a pipe (the
+  // documented `| jq` happy path); calling process.exit(code) immediately
+  // after a sync-style write truncates the pipe buffer. Setting
+  // process.exitCode and letting the loop drain naturally avoids the race.
+  stdout: (s) => {
+    process.stdout.write(s);
+  },
+  stderr: (s) => {
+    process.stderr.write(s);
+  },
 }).then(
-  (code) => process.exit(code),
+  (code) => {
+    // Drain stdout/stderr before letting the process exit. Without an
+    // explicit drain wait, `process.exit(code)` discards pending I/O when
+    // stdout is a pipe — truncating the JSON line the gate workflow
+    // consumes via `jq`. Setting exitCode and letting the event loop
+    // drain naturally is the Node-documented fix.
+    process.exitCode = code;
+  },
   (err) => {
-    process.stderr.write(`fatal: ${(err as Error).stack ?? err}\n`);
-    process.exit(1);
+    process.stderr.write(`fatal: ${formatFatal(err)}\n`);
+    // Exit 2 (invocation/internal error), not 1 (any check failed). The
+    // CLI's exit-code contract distinguishes "your service is broken" (1)
+    // from "your CLI invocation / runtime is broken" (2); an uncaught
+    // throw in runCli is the latter.
+    process.exitCode = 2;
   }
 );

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -1,0 +1,16 @@
+// Bundle entry. esbuild prepends a `#!/usr/bin/env node` shebang to
+// dist/cli.js, so this file is the executable. All testable logic lives
+// in `./cli.js`'s `runCli`; this entry is a thin IO wiring shell so the
+// test suite can import `runCli` directly without firing process.exit.
+import { runCli } from './cli.js';
+
+runCli(process.argv.slice(2), process.env, {
+  stdout: (s) => process.stdout.write(s),
+  stderr: (s) => process.stderr.write(s),
+}).then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`fatal: ${(err as Error).stack ?? err}\n`);
+    process.exit(1);
+  }
+);

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -3,13 +3,17 @@
 // in `./cli.js`'s `runCli`; this entry is a thin IO wiring shell so the
 // test suite can import `runCli` directly without firing process.exit.
 import { runCli } from './cli.js';
+import { sanitizeForLog } from './cli.js';
 
 /**
  * Format a thrown value for the fatal-error stderr line. `err` is typed
  * `unknown` because library code may `throw 'string'` / `throw {code:'X'}`
  * / `throw undefined`. The early `err instanceof Error` branch keeps the
  * stack trace; the else branch coerces with care so we never print a bare
- * `undefined` or `[object Object]`.
+ * `undefined` or `[object Object]`. The caller passes the result through
+ * `sanitizeForLog` before writing to stderr — attacker text leaked via a
+ * thrown Error message would otherwise bypass the per-outcome sanitizer
+ * and forge a fake summary line in the GHA workflow log.
  */
 function formatFatal(err: unknown): string {
   if (err instanceof Error) {
@@ -27,12 +31,37 @@ function formatFatal(err: unknown): string {
   return String(err);
 }
 
+/**
+ * Wait for stdout/stderr to drain, then force exit with the given code.
+ *
+ * `process.exit(code)` discards pending I/O when stdout is a pipe (the
+ * documented `| jq` happy path), truncating the JSON line the gate
+ * workflow consumes. Setting `process.exitCode` and waiting for the
+ * loop to drain naturally is the textbook fix — except Node's global
+ * `fetch` (undici) keeps an HTTP connection pool alive after the last
+ * request (default ~4s idle keepalive; up to 60s on servers with
+ * aggressive Keep-Alive headers). Letting the loop drain there means
+ * the CLI hangs that long after writing its JSON, which compounds
+ * across BS+LML+dj-site gate legs.
+ *
+ * The compromise: wait for explicit stdout/stderr drain callbacks, then
+ * call `process.exit(code)` — by the time both drain callbacks fire,
+ * the pipe buffer has flushed, but the connection pool is still alive;
+ * the explicit exit closes everything without waiting for the pool to
+ * idle out.
+ */
+async function exitAfterDrain(code: number): Promise<never> {
+  // Trigger empty writes whose callbacks fire after the previously
+  // queued bytes have flushed to the underlying transport. If the
+  // streams are already drained, the callback fires on the next tick.
+  await Promise.all([
+    new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
+    new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+  ]);
+  process.exit(code);
+}
+
 runCli(process.argv.slice(2), process.env, {
-  // Wrap stdout/stderr writes so the entry can await pipe drainage before
-  // exiting. `process.stdout.write` is async when stdout is a pipe (the
-  // documented `| jq` happy path); calling process.exit(code) immediately
-  // after a sync-style write truncates the pipe buffer. Setting
-  // process.exitCode and letting the loop drain naturally avoids the race.
   stdout: (s) => {
     process.stdout.write(s);
   },
@@ -41,19 +70,19 @@ runCli(process.argv.slice(2), process.env, {
   },
 }).then(
   (code) => {
-    // Drain stdout/stderr before letting the process exit. Without an
-    // explicit drain wait, `process.exit(code)` discards pending I/O when
-    // stdout is a pipe — truncating the JSON line the gate workflow
-    // consumes via `jq`. Setting exitCode and letting the event loop
-    // drain naturally is the Node-documented fix.
-    process.exitCode = code;
+    void exitAfterDrain(code);
   },
   (err) => {
-    process.stderr.write(`fatal: ${formatFatal(err)}\n`);
+    // Sanitize before write — formatFatal may interpolate err.message
+    // that originated from a server response body (`canaryFetch` errors
+    // include `r.rawText.slice(0, 200)` in their messages). Without
+    // sanitization the fatal-error path bypasses the log-injection
+    // defense the per-outcome sanitizer was added for.
+    process.stderr.write(`fatal: ${sanitizeForLog(formatFatal(err))}\n`);
     // Exit 2 (invocation/internal error), not 1 (any check failed). The
     // CLI's exit-code contract distinguishes "your service is broken" (1)
     // from "your CLI invocation / runtime is broken" (2); an uncaught
     // throw in runCli is the latter.
-    process.exitCode = 2;
+    void exitAfterDrain(2);
   }
 );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,189 @@
+import { parseArgs, type ParseArgsConfig } from 'node:util';
+import { checksForSuite, VALID_SUITES } from './checks.js';
+import { runCanary } from './handler.js';
+import type { CanaryConfig, Suite } from './types.js';
+
+/**
+ * The wxyc-canary CLI shim consumed by the WXYC/wiki#80 staging-gate
+ * workflows (wxyc-shared `bs-lml-gate.yml`, dj-site `staging-gate.yml`).
+ * Wraps the Lambda's `runCanary` so a GitHub Actions runner can invoke
+ * the same probes against staging URLs without dragging the
+ * Lambda-specific side effects (CloudWatch publish, SSM PAT resolution
+ * for GH-issue mirroring and runner-liveness, Secrets Manager for DJ
+ * credentials and the LML bearer). Credentials come from env vars only;
+ * URLs come from flags. Lambda-only checks (gha-runner-online,
+ * enrichment-quality, etc.) are not in any suite and therefore
+ * unreachable from this entry point — see `checksForSuite` in
+ * `checks.ts`.
+ *
+ * Exit codes:
+ *   - 0 — every check returned `pass` or `skipped`.
+ *   - 1 — at least one check returned `fail`. Stdout JSON names which.
+ *   - 2 — invocation error (unknown subcommand, missing required flag,
+ *         unknown flag, unknown suite, --help with bad flags). Stderr
+ *         carries the human-readable reason. Distinct from exit 1 so the
+ *         calling workflow can tell "your invocation is wrong" from
+ *         "your service is broken".
+ */
+
+export type CliStreams = {
+  stdout: (s: string) => void;
+  stderr: (s: string) => void;
+};
+
+const USAGE = `wxyc-canary check [options]
+
+Invokes wxyc-canary checks against an arbitrary BS/LML URL set. Designed
+for the WXYC staging-gate workflows; not a replacement for the prod
+Lambda.
+
+Required flags:
+  --base-url=<url>            Backend-Service base URL (no trailing slash)
+  --auth-url=<url>            better-auth base URL (BS '/auth' route)
+  --lml-url=<url>             library-metadata-lookup base URL
+  --suite=<name>              one of: ${VALID_SUITES.join(', ')}
+
+Environment variables (credentials — flags would leak into shell history):
+  CANARY_DJ_EMAIL             optional; DJ-auth checks skip without it
+  CANARY_DJ_PASSWORD          optional; pairs with CANARY_DJ_EMAIL
+  CANARY_LML_API_KEY          optional; lml-auth check skips without it
+  CANARY_ORIGIN_URL           optional; sent as Origin header on auth calls
+                              (must match a BETTER_AUTH_TRUSTED_ORIGINS
+                              value; defaults to https://dj.wxyc.org)
+  CANARY_TIMEOUT_MS           optional; per-check fetch timeout
+
+Exit codes:
+  0  all checks passed or skipped
+  1  at least one check failed
+  2  invocation error (bad flags, unknown suite, etc.)
+
+Output:
+  stdout: one JSON line with {suite, outcomes, passed, failed, skipped}
+  stderr: human-readable summary
+`;
+
+const parseConfig = {
+  options: {
+    'base-url': { type: 'string' },
+    'auth-url': { type: 'string' },
+    'lml-url': { type: 'string' },
+    suite: { type: 'string' },
+    help: { type: 'boolean', short: 'h' },
+  },
+  // Reject unknown flags rather than silently ignoring them — operator
+  // typos (--dj-email instead of CANARY_DJ_EMAIL) need to fail loudly so
+  // the gate run doesn't quietly skip credential-dependent checks.
+  strict: true,
+  allowPositionals: true,
+} as const satisfies ParseArgsConfig;
+
+function isValidSuite(s: string): s is Suite {
+  return (VALID_SUITES as readonly string[]).includes(s);
+}
+
+export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStreams): Promise<number> {
+  // Early --help (works with or without a subcommand). parseArgs would
+  // also accept `--help` mixed with the other flags, but matching here
+  // means an operator running `wxyc-canary --help` (no subcommand) gets
+  // usage rather than the "unknown subcommand" error.
+  if (argv.includes('--help') || argv.includes('-h')) {
+    io.stdout(USAGE);
+    return 0;
+  }
+
+  let parsed;
+  try {
+    parsed = parseArgs({ ...parseConfig, args: argv });
+  } catch (err) {
+    // parseArgs throws ERR_PARSE_ARGS_UNKNOWN_OPTION etc. for unknown
+    // flags. Forward the message so the operator sees which flag.
+    io.stderr(`${(err as Error).message}\n`);
+    io.stderr(USAGE);
+    return 2;
+  }
+
+  const positionals = parsed.positionals;
+  const subcommand = positionals[0];
+  if (subcommand !== 'check') {
+    io.stderr(
+      subcommand === undefined
+        ? 'missing subcommand (expected: check)\n'
+        : `unknown subcommand '${subcommand}' (expected: check)\n`
+    );
+    io.stderr(USAGE);
+    return 2;
+  }
+
+  const values = parsed.values;
+  const missing: string[] = [];
+  if (!values['base-url']) missing.push('--base-url');
+  if (!values['auth-url']) missing.push('--auth-url');
+  if (!values['lml-url']) missing.push('--lml-url');
+  if (!values.suite) missing.push('--suite');
+  if (missing.length > 0) {
+    io.stderr(`missing required flag(s): ${missing.join(', ')}\n`);
+    io.stderr(USAGE);
+    return 2;
+  }
+
+  const suiteArg = values.suite as string;
+  if (!isValidSuite(suiteArg)) {
+    io.stderr(`unknown suite '${suiteArg}' (valid: ${VALID_SUITES.join(', ')})\n`);
+    return 2;
+  }
+
+  // Build the CanaryConfig from flags + env. Credentials are env-only on
+  // purpose — putting `--dj-password` on the command line would leak the
+  // bearer into shell history, process listings, and CI run logs.
+  const config: CanaryConfig = {
+    backendUrl: values['base-url'] as string,
+    authUrl: values['auth-url'] as string,
+    semanticIndexUrl: '',
+    lmlUrl: values['lml-url'] as string,
+    djEmail: env.CANARY_DJ_EMAIL,
+    djPassword: env.CANARY_DJ_PASSWORD,
+    lmlApiKey: env.CANARY_LML_API_KEY,
+    originUrl: env.CANARY_ORIGIN_URL,
+    timeoutMs: env.CANARY_TIMEOUT_MS ? Number(env.CANARY_TIMEOUT_MS) : undefined,
+    // Hard-off: the CLI must never publish CloudWatch metrics (it has no
+    // AWS credentials and the staging probes don't belong on the prod
+    // dashboards).
+    publishMetrics: false,
+    // Hard-off: writes are a Lambda-scheduled signal, not a gate signal
+    // (45s poll budget makes them a poor blocker for PR merges).
+    enableWriteProbe: false,
+  };
+
+  const outcomes = await runCanary(config, { checks: checksForSuite(suiteArg) });
+
+  const passed = outcomes.filter((o) => o.status === 'pass').length;
+  const failed = outcomes.filter((o) => o.status === 'fail').length;
+  const skipped = outcomes.filter((o) => o.status === 'skipped').length;
+
+  io.stdout(
+    JSON.stringify({
+      suite: suiteArg,
+      passed,
+      failed,
+      skipped,
+      outcomes,
+    }) + '\n'
+  );
+
+  // Stderr summary: always include the headline + every non-pass with
+  // its message so a workflow log reader sees the failing surface
+  // without piping stdout through jq.
+  const summaryLines = [
+    `suite=${suiteArg} passed=${passed} failed=${failed} skipped=${skipped}`,
+    ...outcomes
+      .filter((o) => o.status !== 'pass')
+      .map((o) => `  ${o.status} ${o.name} (${o.latencyMs}ms)${o.message ? ` — ${o.message}` : ''}`),
+  ];
+  io.stderr(summaryLines.join('\n') + '\n');
+
+  return failed > 0 ? 1 : 0;
+}
+
+// Note: the bundle entry point is `src/cli-entry.ts`, which calls
+// `runCli` and wires it to `process` IO. This file stays import-safe —
+// vitest imports `runCli` here without side effects.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { parseArgs, type ParseArgsConfig } from 'node:util';
 import { checksForSuite, VALID_SUITES } from './checks.js';
 import { runCanary } from './handler.js';
-import type { CanaryConfig, Suite } from './types.js';
+import type { CanaryConfig, CheckOutcome, Suite } from './types.js';
 
 /**
  * The wxyc-canary CLI shim consumed by the WXYC/wiki#80 staging-gate
@@ -44,13 +44,15 @@ Required flags:
   --suite=<name>              one of: ${VALID_SUITES.join(', ')}
 
 Environment variables (credentials — flags would leak into shell history):
-  CANARY_DJ_EMAIL             optional; DJ-auth checks skip without it
-  CANARY_DJ_PASSWORD          optional; pairs with CANARY_DJ_EMAIL
+  CANARY_DJ_EMAIL             DJ login email. Pairs with CANARY_DJ_PASSWORD;
+                              both must be set together or both unset
+                              (XOR is rejected as an invocation error).
+                              When both unset, DJ-auth checks skip.
+  CANARY_DJ_PASSWORD          DJ login password. See above.
   CANARY_LML_API_KEY          optional; lml-auth check skips without it
   CANARY_ORIGIN_URL           optional; sent as Origin header on auth calls
                               (must match a BETTER_AUTH_TRUSTED_ORIGINS
                               value; defaults to https://dj.wxyc.org)
-  CANARY_TIMEOUT_MS           optional; per-check fetch timeout
 
 Exit codes:
   0  all checks passed or skipped
@@ -59,6 +61,7 @@ Exit codes:
 
 Output:
   stdout: one JSON line with {suite, outcomes, passed, failed, skipped}
+          where each outcome is {name, status, latencyMs, message?}
   stderr: human-readable summary
 `;
 
@@ -81,16 +84,38 @@ function isValidSuite(s: string): s is Suite {
   return (VALID_SUITES as readonly string[]).includes(s);
 }
 
-export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStreams): Promise<number> {
-  // Early --help (works with or without a subcommand). parseArgs would
-  // also accept `--help` mixed with the other flags, but matching here
-  // means an operator running `wxyc-canary --help` (no subcommand) gets
-  // usage rather than the "unknown subcommand" error.
-  if (argv.includes('--help') || argv.includes('-h')) {
-    io.stdout(USAGE);
-    return 0;
-  }
+/**
+ * Strip control characters from text that originated outside the CLI
+ * (HTTP response bodies surfaced inside CheckOutcome.message). Without
+ * this, a probed endpoint serving attacker-controlled text could inject
+ * newlines into the stderr summary and forge a misleading "passed=5
+ * failed=0" trailer in the GHA workflow log.
+ */
+function sanitizeForLog(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x1f\x7f]/g, ' ');
+}
 
+/**
+ * Project the CheckOutcome shape to the documented CLI contract
+ * (name, status, latencyMs, optional message). Strips fields like
+ * `metrics` that the Lambda may attach to outcomes — the CLI's stdout
+ * contract is narrower than the Lambda's internal data shape, and a
+ * future check that returns custom metrics must not silently leak them
+ * into the gate workflow's parsed JSON.
+ */
+function projectOutcomeForStdout(o: CheckOutcome): {
+  name: string;
+  status: 'pass' | 'fail' | 'skipped';
+  latencyMs: number;
+  message?: string;
+} {
+  return o.message === undefined
+    ? { name: o.name, status: o.status, latencyMs: o.latencyMs }
+    : { name: o.name, status: o.status, latencyMs: o.latencyMs, message: o.message };
+}
+
+export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStreams): Promise<number> {
   let parsed;
   try {
     parsed = parseArgs({ ...parseConfig, args: argv });
@@ -102,6 +127,16 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
     return 2;
   }
 
+  // --help is honored only AFTER parseArgs accepts the rest of the
+  // flag set. Doing it earlier (e.g. `argv.includes('--help')`) would
+  // mask unknown-flag / typo errors that the strict parser was meant to
+  // catch — an operator running `wxyc-canary check --help --typo-flag`
+  // would get exit 0 and never learn about the typo.
+  if (parsed.values.help) {
+    io.stdout(USAGE);
+    return 0;
+  }
+
   const positionals = parsed.positionals;
   const subcommand = positionals[0];
   if (subcommand !== 'check') {
@@ -110,6 +145,15 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
         ? 'missing subcommand (expected: check)\n'
         : `unknown subcommand '${subcommand}' (expected: check)\n`
     );
+    io.stderr(USAGE);
+    return 2;
+  }
+  // Reject extra positionals — `wxyc-canary check smoke` (positional
+  // suite name) and `wxyc-canary check --suite=smoke leftover` both fall
+  // here. parseArgs's `strict: true` governs flags only; positionals are
+  // always permissive with `allowPositionals: true`.
+  if (positionals.length > 1) {
+    io.stderr(`unexpected positional argument(s): ${positionals.slice(1).join(', ')}\n`);
     io.stderr(USAGE);
     return 2;
   }
@@ -129,6 +173,21 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
   const suiteArg = values.suite as string;
   if (!isValidSuite(suiteArg)) {
     io.stderr(`unknown suite '${suiteArg}' (valid: ${VALID_SUITES.join(', ')})\n`);
+    io.stderr(USAGE);
+    return 2;
+  }
+
+  // DJ creds must be set together. XOR (only one set) was previously
+  // silently degraded to "no DJ credentials configured" because
+  // resolveDjCredentials in handler.ts requires both. Surfacing it as
+  // an invocation error keeps the gate operator from shipping a workflow
+  // where DJ-auth checks are accidentally skipped.
+  const djEmailSet = !!env.CANARY_DJ_EMAIL;
+  const djPasswordSet = !!env.CANARY_DJ_PASSWORD;
+  if (djEmailSet !== djPasswordSet) {
+    io.stderr(
+      `CANARY_DJ_EMAIL and CANARY_DJ_PASSWORD must be set together (found: EMAIL=${djEmailSet ? 'set' : 'unset'}, PASSWORD=${djPasswordSet ? 'set' : 'unset'})\n`
+    );
     return 2;
   }
 
@@ -138,23 +197,46 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
   const config: CanaryConfig = {
     backendUrl: values['base-url'] as string,
     authUrl: values['auth-url'] as string,
+    // semanticIndexUrl is required on CanaryConfig but unused by every
+    // smoke check. The empty string is a tripwire: if a future suite
+    // ever includes `semantic-index-search` without surfacing this
+    // field as a flag, the check will fail with a clear URL-construction
+    // error rather than silently hitting the wrong host.
     semanticIndexUrl: '',
     lmlUrl: values['lml-url'] as string,
     djEmail: env.CANARY_DJ_EMAIL,
     djPassword: env.CANARY_DJ_PASSWORD,
     lmlApiKey: env.CANARY_LML_API_KEY,
     originUrl: env.CANARY_ORIGIN_URL,
-    timeoutMs: env.CANARY_TIMEOUT_MS ? Number(env.CANARY_TIMEOUT_MS) : undefined,
-    // Hard-off: the CLI must never publish CloudWatch metrics (it has no
-    // AWS credentials and the staging probes don't belong on the prod
-    // dashboards).
+    // Defensive: `runCanary` doesn't currently read publishMetrics (the
+    // flag governs only the Lambda `handler()` wrapper), but a future
+    // refactor that moves the publish step into runCanary should
+    // honor this guard. Setting it here documents the CLI's intent.
     publishMetrics: false,
-    // Hard-off: writes are a Lambda-scheduled signal, not a gate signal
-    // (45s poll budget makes them a poor blocker for PR merges).
+    // Defensive: same shape — enableWriteProbe gates the
+    // `enrichment-quality` check, which isn't in any suite, so this
+    // flag is unreachable by the CLI today. Set explicitly to harden
+    // against a future suite addition.
     enableWriteProbe: false,
   };
 
-  const outcomes = await runCanary(config, { checks: checksForSuite(suiteArg) });
+  // Pass a sanitized env to runCanary so its resolver helpers
+  // (`resolveDjCredentials`, `resolveLmlApiKey`, `resolveGhaRunnerToken`)
+  // can't reach for AWS-SDK secret backends via env vars the CLI doesn't
+  // advertise. Without this, an operator with CANARY_DJ_SECRET_ARN
+  // exported in their shell would silently trigger SecretsManagerClient
+  // instantiation despite the README's "no AWS SDK" contract.
+  const sanitizedEnv: NodeJS.ProcessEnv = {
+    CANARY_DJ_EMAIL: env.CANARY_DJ_EMAIL,
+    CANARY_DJ_PASSWORD: env.CANARY_DJ_PASSWORD,
+    CANARY_LML_API_KEY: env.CANARY_LML_API_KEY,
+    CANARY_ORIGIN_URL: env.CANARY_ORIGIN_URL,
+  };
+
+  const outcomes = await runCanary(config, {
+    checks: checksForSuite(suiteArg),
+    env: sanitizedEnv,
+  });
 
   const passed = outcomes.filter((o) => o.status === 'pass').length;
   const failed = outcomes.filter((o) => o.status === 'fail').length;
@@ -166,18 +248,25 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
       passed,
       failed,
       skipped,
-      outcomes,
+      outcomes: outcomes.map(projectOutcomeForStdout),
     }) + '\n'
   );
 
   // Stderr summary: always include the headline + every non-pass with
   // its message so a workflow log reader sees the failing surface
-  // without piping stdout through jq.
+  // without piping stdout through jq. Sanitize the message — it
+  // originates from check error throws that interpolate `r.rawText`
+  // slices (server response bodies); a probed endpoint serving
+  // attacker-controlled text could otherwise inject newlines and forge
+  // a misleading trailer in the GHA workflow log.
   const summaryLines = [
     `suite=${suiteArg} passed=${passed} failed=${failed} skipped=${skipped}`,
     ...outcomes
       .filter((o) => o.status !== 'pass')
-      .map((o) => `  ${o.status} ${o.name} (${o.latencyMs}ms)${o.message ? ` — ${o.message}` : ''}`),
+      .map((o) => {
+        const msg = o.message ? ` — ${sanitizeForLog(o.message)}` : '';
+        return `  ${o.status} ${o.name} (${o.latencyMs}ms)${msg}`;
+      }),
   ];
   io.stderr(summaryLines.join('\n') + '\n');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,15 +85,25 @@ function isValidSuite(s: string): s is Suite {
 }
 
 /**
- * Strip control characters from text that originated outside the CLI
- * (HTTP response bodies surfaced inside CheckOutcome.message). Without
- * this, a probed endpoint serving attacker-controlled text could inject
- * newlines into the stderr summary and forge a misleading "passed=5
- * failed=0" trailer in the GHA workflow log.
+ * Strip control characters AND Unicode line terminators from text that
+ * originated outside the CLI (HTTP response bodies surfaced inside
+ * CheckOutcome.message, fatal-error messages). Without this, a probed
+ * endpoint serving attacker-controlled text could inject newlines into
+ * the stderr summary and forge a misleading "passed=5 failed=0" trailer
+ * in the GHA workflow log.
+ *
+ * Covers:
+ *  - ASCII C0 controls (0x00–0x1f, includes \\n, \\r, \\t, ESC for ANSI)
+ *  - DEL (0x7f)
+ *  - C1 controls (0x80–0x9f, includes CSI single-byte forms)
+ *  - U+2028 LINE SEPARATOR, U+2029 PARAGRAPH SEPARATOR (JS/JSON-aware
+ *    log parsers treat these as line breaks; the regex must catch them
+ *    or the same injection forgery returns via Unicode).
+ *  - U+0085 NEL (NEXT LINE)
  */
-function sanitizeForLog(s: string): string {
+export function sanitizeForLog(s: string): string {
   // eslint-disable-next-line no-control-regex
-  return s.replace(/[\x00-\x1f\x7f]/g, ' ');
+  return s.replace(/[\x00-\x1f\x7f-\x9f\u0085\u2028\u2029]/g, ' ');
 }
 
 /**
@@ -158,33 +168,59 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
     return 2;
   }
 
-  const values = parsed.values;
+  // Normalize string flag values: trim whitespace, treat empty-after-trim
+  // as missing. `--base-url=' '` would otherwise pass the truthy-string
+  // check, propagate the whitespace into backendUrl, and surface as a
+  // cryptic "Invalid URL" error from canaryFetch instead of the clean
+  // exit-2 "missing required flag" contract.
+  const trim = (k: keyof typeof parsed.values): string | undefined => {
+    const v = parsed.values[k];
+    if (typeof v !== 'string') return undefined;
+    const t = v.trim();
+    return t === '' ? undefined : t;
+  };
+  const baseUrl = trim('base-url');
+  const authUrl = trim('auth-url');
+  const lmlUrl = trim('lml-url');
+  const suiteRaw = trim('suite');
+
   const missing: string[] = [];
-  if (!values['base-url']) missing.push('--base-url');
-  if (!values['auth-url']) missing.push('--auth-url');
-  if (!values['lml-url']) missing.push('--lml-url');
-  if (!values.suite) missing.push('--suite');
+  if (!baseUrl) missing.push('--base-url');
+  if (!authUrl) missing.push('--auth-url');
+  if (!lmlUrl) missing.push('--lml-url');
+  if (!suiteRaw) missing.push('--suite');
   if (missing.length > 0) {
     io.stderr(`missing required flag(s): ${missing.join(', ')}\n`);
     io.stderr(USAGE);
     return 2;
   }
 
-  const suiteArg = values.suite as string;
-  if (!isValidSuite(suiteArg)) {
-    io.stderr(`unknown suite '${suiteArg}' (valid: ${VALID_SUITES.join(', ')})\n`);
+  if (!isValidSuite(suiteRaw as string)) {
+    io.stderr(`unknown suite '${suiteRaw}' (valid: ${VALID_SUITES.join(', ')})\n`);
     io.stderr(USAGE);
     return 2;
   }
+  const suiteArg = suiteRaw as Suite;
 
   // DJ creds must be set together. XOR (only one set) was previously
   // silently degraded to "no DJ credentials configured" because
   // resolveDjCredentials in handler.ts requires both. Surfacing it as
   // an invocation error keeps the gate operator from shipping a workflow
   // where DJ-auth checks are accidentally skipped.
-  const djEmailSet = !!env.CANARY_DJ_EMAIL;
-  const djPasswordSet = !!env.CANARY_DJ_PASSWORD;
-  if (djEmailSet !== djPasswordSet) {
+  //
+  // `.trim()` + truthy check catches whitespace-only values from CI
+  // variable substitution (e.g. `${{ secrets.MISSING_SECRET }}` expands
+  // to empty string; `${UNSET:-}` expands similarly). Without the trim
+  // an operator with `CANARY_DJ_EMAIL=' '` would pass the XOR gate, then
+  // sign-in 401s as a real-DJ-auth-down failure on every gate run.
+  //
+  // Gate the check on whether the resolved suite actually needs DJ auth
+  // — a future non-DJ suite (e.g. read-only public surfaces) shouldn't
+  // surface an XOR error to operators who happen to have one half set.
+  const djEmailSet = !!env.CANARY_DJ_EMAIL?.trim();
+  const djPasswordSet = !!env.CANARY_DJ_PASSWORD?.trim();
+  const suiteNeedsDj = checksForSuite(suiteArg).some((c) => c.requiresAuth);
+  if (suiteNeedsDj && djEmailSet !== djPasswordSet) {
     io.stderr(
       `CANARY_DJ_EMAIL and CANARY_DJ_PASSWORD must be set together (found: EMAIL=${djEmailSet ? 'set' : 'unset'}, PASSWORD=${djPasswordSet ? 'set' : 'unset'})\n`
     );
@@ -195,15 +231,16 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv, io: CliStre
   // purpose — putting `--dj-password` on the command line would leak the
   // bearer into shell history, process listings, and CI run logs.
   const config: CanaryConfig = {
-    backendUrl: values['base-url'] as string,
-    authUrl: values['auth-url'] as string,
+    // Use the trimmed URL values (already validated as non-empty).
+    backendUrl: baseUrl as string,
+    authUrl: authUrl as string,
     // semanticIndexUrl is required on CanaryConfig but unused by every
     // smoke check. The empty string is a tripwire: if a future suite
     // ever includes `semantic-index-search` without surfacing this
     // field as a flag, the check will fail with a clear URL-construction
     // error rather than silently hitting the wrong host.
     semanticIndexUrl: '',
-    lmlUrl: values['lml-url'] as string,
+    lmlUrl: lmlUrl as string,
     djEmail: env.CANARY_DJ_EMAIL,
     djPassword: env.CANARY_DJ_PASSWORD,
     lmlApiKey: env.CANARY_LML_API_KEY,

--- a/src/handler-local.ts
+++ b/src/handler-local.ts
@@ -9,9 +9,15 @@ import { handler } from './handler.js';
 // the drain step `npm run local | jq` could see truncated output. Same
 // pattern as `cli-entry.ts`.
 async function exitAfterDrain(code: number): Promise<never> {
-  await Promise.all([
-    new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
-    new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+  // Cap drain wait at 500ms so a wedged pipe (EPIPE from a reader that
+  // hung up mid-write) doesn't leave the process hanging. See
+  // cli-entry.ts for the full rationale.
+  await Promise.race([
+    Promise.all([
+      new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
+      new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+    ]),
+    new Promise<void>((resolve) => setTimeout(resolve, 500).unref()),
   ]);
   process.exit(code);
 }

--- a/src/handler-local.ts
+++ b/src/handler-local.ts
@@ -1,0 +1,12 @@
+// Local-invocation entry for `npm run local`. Kept separate from
+// handler.ts so the CLI can import `runCanary` without firing this
+// autorun. The Lambda runtime invokes `handler.handler` directly and
+// has no reason to reach this file.
+import { handler } from './handler.js';
+
+handler()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/handler-local.ts
+++ b/src/handler-local.ts
@@ -4,9 +4,22 @@
 // has no reason to reach this file.
 import { handler } from './handler.js';
 
-handler()
-  .then(() => process.exit(0))
-  .catch((err) => {
+// Drain stdout/stderr before forcing exit — the Lambda `handler()`
+// writes its JSON via `console.log` which is async to a pipe; without
+// the drain step `npm run local | jq` could see truncated output. Same
+// pattern as `cli-entry.ts`.
+async function exitAfterDrain(code: number): Promise<never> {
+  await Promise.all([
+    new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
+    new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+  ]);
+  process.exit(code);
+}
+
+handler().then(
+  () => exitAfterDrain(0),
+  (err) => {
     console.error(err);
-    process.exit(1);
-  });
+    return exitAfterDrain(1);
+  }
+);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -47,17 +47,28 @@ function loadConfigFromEnv(): CanaryConfig {
 
 /**
  * Resolve DJ credentials from one of two sources, in order:
- *   1. `CANARY_DJ_EMAIL` + `CANARY_DJ_PASSWORD` env vars (local + tests).
- *   2. `CANARY_DJ_SECRET_ARN` pointing at a Secrets Manager secret with a
- *      JSON value of shape `{"email": "...", "password": "..."}` (prod).
+ *   1. `config.djEmail` + `config.djPassword` (set by the Lambda's
+ *      env loader or the CLI's flag-parser).
+ *   2. `env.CANARY_DJ_SECRET_ARN` pointing at a Secrets Manager secret
+ *      with a JSON value of shape `{"email": "...", "password": "..."}`.
  * Returns undefined when neither is configured — DJ-auth checks downgrade
  * to skipped in that case.
+ *
+ * `env` is passed explicitly (not read from `process.env`) so callers
+ * that want to suppress the SecretsManager fallback can pass a
+ * sanitized env. The CLI does exactly that — its README contracts on
+ * "never instantiates the AWS SDK", and an operator with
+ * `CANARY_DJ_SECRET_ARN` in their shell would otherwise silently
+ * trigger SDK instantiation despite the CLI's intent.
  */
-async function resolveDjCredentials(config: CanaryConfig): Promise<{ email: string; password: string } | undefined> {
+async function resolveDjCredentials(
+  config: CanaryConfig,
+  env: NodeJS.ProcessEnv
+): Promise<{ email: string; password: string } | undefined> {
   if (config.djEmail && config.djPassword) {
     return { email: config.djEmail, password: config.djPassword };
   }
-  const secretArn = process.env.CANARY_DJ_SECRET_ARN;
+  const secretArn = env.CANARY_DJ_SECRET_ARN;
   if (!secretArn) return undefined;
 
   const sm = new SecretsManagerClient({ region: config.awsRegion ?? 'us-east-1' });
@@ -74,17 +85,19 @@ async function resolveDjCredentials(config: CanaryConfig): Promise<{ email: stri
 
 /**
  * Resolve the LML bearer from one of two sources, in order:
- *   1. `CANARY_LML_API_KEY` env var (local + tests + simple prod).
- *   2. `CANARY_LML_API_KEY_SECRET_ARN` pointing at a Secrets Manager
+ *   1. `config.lmlApiKey` (set by env loader / CLI flag-parser).
+ *   2. `env.CANARY_LML_API_KEY_SECRET_ARN` pointing at a Secrets Manager
  *      secret whose `SecretString` is the bearer itself (plain string,
  *      not JSON — Railway-style secret-store convention so the bearer
  *      rotates in one place across BS + rom + tubafrenzy + canary).
  * Returns undefined when neither is configured — the `lml-auth` check
  * then downgrades to skipped (operator gap, not regression).
+ *
+ * See `resolveDjCredentials` for the env-parameter rationale.
  */
-async function resolveLmlApiKey(config: CanaryConfig): Promise<string | undefined> {
+async function resolveLmlApiKey(config: CanaryConfig, env: NodeJS.ProcessEnv): Promise<string | undefined> {
   if (config.lmlApiKey) return config.lmlApiKey;
-  const secretArn = process.env.CANARY_LML_API_KEY_SECRET_ARN;
+  const secretArn = env.CANARY_LML_API_KEY_SECRET_ARN;
   if (!secretArn) return undefined;
 
   const sm = new SecretsManagerClient({ region: config.awsRegion ?? 'us-east-1' });
@@ -97,17 +110,19 @@ async function resolveLmlApiKey(config: CanaryConfig): Promise<string | undefine
 
 /**
  * Resolve the GitHub PAT used by the `gha-runner-online` check, in order:
- *   1. `CANARY_GHA_RUNNER_TOKEN` env (local + tests).
- *   2. `CANARY_GHA_RUNNER_TOKEN_SSM_PARAM` → SSM SecureString (prod).
+ *   1. `config.ghaRunnerToken` (set by env loader / CLI flag-parser).
+ *   2. `env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM` → SSM SecureString.
  * Returns undefined when neither is configured — the check then skips
  * with reason. The PAT is stored in SSM (not Secrets Manager) to match
  * the existing GitHub-issues-reporter PAT, which keeps all GitHub-PAT
  * storage co-located under `/wxyc-canary/*` for the same rotation
  * cadence and IAM grant pattern.
+ *
+ * See `resolveDjCredentials` for the env-parameter rationale.
  */
-async function resolveGhaRunnerToken(config: CanaryConfig): Promise<string | undefined> {
+async function resolveGhaRunnerToken(config: CanaryConfig, env: NodeJS.ProcessEnv): Promise<string | undefined> {
   if (config.ghaRunnerToken) return config.ghaRunnerToken;
-  const paramName = process.env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM;
+  const paramName = env.CANARY_GHA_RUNNER_TOKEN_SSM_PARAM;
   if (!paramName) return undefined;
 
   const ssm = new SSMClient({ region: config.awsRegion ?? 'us-east-1' });
@@ -134,12 +149,20 @@ async function resolveGhaRunnerToken(config: CanaryConfig): Promise<string | und
  * logic (lml-auth no-bearer, dj-* no-creds) still works when the suite
  * happens to include the affected check.
  */
-export async function runCanary(config: CanaryConfig, opts?: { checks?: readonly Check[] }): Promise<CheckOutcome[]> {
+export async function runCanary(
+  config: CanaryConfig,
+  opts?: { checks?: readonly Check[]; env?: NodeJS.ProcessEnv }
+): Promise<CheckOutcome[]> {
   const ranChecks = opts?.checks ?? checks;
+  // `env` defaults to `process.env` for the Lambda call path (which
+  // wants the SecretsManager / SSM fallbacks to fire). The CLI passes
+  // a sanitized env so the fallbacks short-circuit on missing env vars
+  // and never instantiate any AWS SDK client.
+  const env = opts?.env ?? process.env;
   let djCreds: { email: string; password: string } | undefined;
   let djAuthError: string | undefined;
   try {
-    djCreds = await resolveDjCredentials(config);
+    djCreds = await resolveDjCredentials(config, env);
   } catch (err) {
     djAuthError = `credential resolution failed: ${(err as Error).message}`;
   }
@@ -151,7 +174,7 @@ export async function runCanary(config: CanaryConfig, opts?: { checks?: readonly
   let lmlApiKey: string | undefined;
   let lmlAuthError: string | undefined;
   try {
-    lmlApiKey = await resolveLmlApiKey(config);
+    lmlApiKey = await resolveLmlApiKey(config, env);
   } catch (err) {
     lmlAuthError = `LML bearer resolution failed: ${(err as Error).message}`;
   }
@@ -168,7 +191,7 @@ export async function runCanary(config: CanaryConfig, opts?: { checks?: readonly
     typeof config.ghaRunnerId === 'number' && Number.isInteger(config.ghaRunnerId) && config.ghaRunnerId > 0;
   if (probeIdConfigured) {
     try {
-      ghaRunnerToken = await resolveGhaRunnerToken(config);
+      ghaRunnerToken = await resolveGhaRunnerToken(config, env);
     } catch (err) {
       ghaRunnerTokenError = `GH runner PAT resolution failed: ${(err as Error).message}`;
     }
@@ -416,11 +439,9 @@ export const handler = async (): Promise<{ outcomes: CheckOutcome[]; failed: num
   return { outcomes, failed, skipped };
 };
 
-if (process.env.CANARY_LOCAL === 'true') {
-  handler()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error(err);
-      process.exit(1);
-    });
-}
+// The `npm run local` autorun now lives in `src/handler-local.ts` so
+// that `import { runCanary } from './handler.js'` from the CLI never
+// fires a Lambda invocation as a top-level side effect. The race was
+// real: an operator with `CANARY_LOCAL=true` in their shell would
+// otherwise see the Lambda `handler()` execute concurrently with the
+// CLI's `runCli` call.

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,7 +3,7 @@ import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-sec
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { checks, signInDj } from './checks.js';
 import { reportOutcomesToGitHub } from './github-issues.js';
-import type { CanaryConfig, CheckContext, CheckOutcome, CheckResult } from './types.js';
+import type { CanaryConfig, Check, CheckContext, CheckOutcome, CheckResult } from './types.js';
 
 const METRIC_NAMESPACE = 'WXYC/Canary';
 const DEFAULT_ENRICHMENT_POLL_TIMEOUT_MS = 45_000;
@@ -125,8 +125,17 @@ async function resolveGhaRunnerToken(config: CanaryConfig): Promise<string | und
  * are configured — distinct from 'fail' so the alarm only fires on real
  * regressions, not on operator-caused gaps. Write-canary checks also
  * downgrade to 'skipped' when `enableWriteProbe=false` (the default).
+ *
+ * `opts.checks` overrides which checks run — the CLI passes
+ * `checksForSuite('smoke')` here so the staging-gate workflow runs the
+ * BS+LML subset and skips Lambda-only probes (runner-liveness, writes).
+ * Lambda callers omit the opt and get the full `checks` array. Credential
+ * resolution + ctx assembly happen unconditionally so the per-check skip
+ * logic (lml-auth no-bearer, dj-* no-creds) still works when the suite
+ * happens to include the affected check.
  */
-export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
+export async function runCanary(config: CanaryConfig, opts?: { checks?: readonly Check[] }): Promise<CheckOutcome[]> {
+  const ranChecks = opts?.checks ?? checks;
   let djCreds: { email: string; password: string } | undefined;
   let djAuthError: string | undefined;
   try {
@@ -216,7 +225,7 @@ export async function runCanary(config: CanaryConfig): Promise<CheckOutcome[]> {
   };
 
   const outcomes = await Promise.all(
-    checks.map(async (check): Promise<CheckOutcome> => {
+    ranChecks.map(async (check): Promise<CheckOutcome> => {
       if (check.requiresAuth && !djCreds && !djAuthError) {
         return { name: check.name, status: 'skipped', latencyMs: 0, message: 'no DJ credentials configured' };
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,13 @@
 /**
+ * Named subset of `checks` invokable from the CLI. The Lambda always runs
+ * the full `checks` array, ignoring suite tags. Add a suite by extending
+ * this union AND `VALID_SUITES` in `checks.ts` AND tagging the checks that
+ * belong to it. Future likely additions: `'dj-site'` for the dj-site
+ * staging gate, `'full'` for an ad-hoc local sweep.
+ */
+export type Suite = 'smoke';
+
+/**
  * A single canary check that exercises one user-facing surface of the WXYC
  * stack. Each check returns a result; failures don't throw — they're a
  * first-class state so a single broken endpoint doesn't short-circuit the
@@ -19,6 +28,13 @@ export type Check = {
    * them. Defaults to false (read-only).
    */
   writes?: boolean;
+  /**
+   * CLI suite membership. Untagged checks are unreachable from the CLI
+   * (Lambda-only). The set of valid suite tags is the `Suite` union;
+   * `checksForSuite(suite)` filters the global `checks` array by
+   * `suites?.includes(suite)`.
+   */
+  suites?: readonly Suite[];
   /**
    * The actual probe. Throws on failure with a message that's safe to alert
    * on. May optionally return a `CheckResult` carrying custom metrics the

--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { checks, checksForSuite, VALID_SUITES } from '../src/checks.js';
+
+describe('checksForSuite', () => {
+  it('returns the BS+LML smoke set in the expected order', () => {
+    // The order is the canary's docstring order: anonymous-first, then
+    // DJ-authed surfaces. A staging-gate consumer doesn't depend on the
+    // order, but a drift in the tag set is exactly what this test exists
+    // to catch.
+    expect(checksForSuite('smoke').map((c) => c.name)).toEqual([
+      'backend-healthcheck',
+      'proxy-library-search',
+      'dj-library-search',
+      'dj-flowsheet-read',
+      'lml-auth',
+    ]);
+  });
+
+  it('excludes Lambda-only checks from smoke', () => {
+    const smokeNames = checksForSuite('smoke').map((c) => c.name);
+    // Each of these is excluded for a different reason (see plan / README):
+    // semantic-index-search is a different service; dj-rotation* duplicate
+    // or flaky against staging; gha-runner-online is the runner the CLI
+    // runs on; enrichment-quality writes + polls 45s.
+    for (const name of [
+      'semantic-index-search',
+      'dj-rotation',
+      'dj-rotation-picker',
+      'gha-runner-online',
+      'enrichment-quality',
+    ]) {
+      expect(smokeNames).not.toContain(name);
+    }
+  });
+
+  it('every smoke-tagged check still appears in the full checks array', () => {
+    // Catches a refactor that adds a Check with `suites: ['smoke']` but
+    // forgets to wire it into `checks` — the CLI would silently drop it
+    // and the gate would lose a probe.
+    const fullNames = new Set(checks.map((c) => c.name));
+    for (const c of checksForSuite('smoke')) {
+      expect(fullNames).toContain(c.name);
+    }
+  });
+});
+
+describe('VALID_SUITES', () => {
+  it('contains exactly the suite tags supported at v1', () => {
+    // Locked: the CLI's --suite validator reads this constant. Adding a
+    // suite is intentional surface work — extend Suite, add here, tag
+    // checks, then update this assertion.
+    expect([...VALID_SUITES]).toEqual(['smoke']);
+  });
+});

--- a/test/cli-aws-isolation.test.ts
+++ b/test/cli-aws-isolation.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Real-runCanary AWS-SDK isolation test. The companion file `cli.test.ts`
+// mocks `runCanary` and so cannot exercise the SDK-resolver code path —
+// its AWS-SDK-constructor assertion was tautological. This file un-mocks
+// `runCanary` (does not call `vi.mock('../src/handler.js')` at all) and
+// feeds the CLI an env polluted with the exact secret-store pointers
+// that would normally cause `resolveDjCredentials` /
+// `resolveLmlApiKey` / `resolveGhaRunnerToken` to instantiate
+// SecretsManagerClient or SSMClient. If the CLI's env-sanitization
+// layer works as designed, none of those constructors should fire.
+//
+// We mock fetch instead so the actual HTTP probes don't go out.
+
+const { cloudWatchCtorSpy, ssmCtorSpy, secretsManagerCtorSpy } = vi.hoisted(() => ({
+  cloudWatchCtorSpy: vi.fn(),
+  ssmCtorSpy: vi.fn(),
+  secretsManagerCtorSpy: vi.fn(),
+}));
+vi.mock('@aws-sdk/client-cloudwatch', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-cloudwatch')>('@aws-sdk/client-cloudwatch');
+  return {
+    ...actual,
+    CloudWatchClient: vi.fn().mockImplementation((...args: unknown[]) => {
+      cloudWatchCtorSpy(...args);
+      return { send: vi.fn(async () => ({})) };
+    }),
+  };
+});
+vi.mock('@aws-sdk/client-ssm', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-ssm')>('@aws-sdk/client-ssm');
+  return {
+    ...actual,
+    SSMClient: vi.fn().mockImplementation((...args: unknown[]) => {
+      ssmCtorSpy(...args);
+      return { send: vi.fn(async () => ({})) };
+    }),
+  };
+});
+vi.mock('@aws-sdk/client-secrets-manager', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-secrets-manager')>(
+    '@aws-sdk/client-secrets-manager'
+  );
+  return {
+    ...actual,
+    SecretsManagerClient: vi.fn().mockImplementation((...args: unknown[]) => {
+      secretsManagerCtorSpy(...args);
+      return { send: vi.fn(async () => ({})) };
+    }),
+  };
+});
+
+import { runCli, type CliStreams } from '../src/cli.js';
+
+function setUpStreams(): { io: CliStreams; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    io: {
+      stdout: (s) => stdout.push(s),
+      stderr: (s) => stderr.push(s),
+    },
+  };
+}
+
+// Mock fetch so the CLI's probes don't hit real network. Every smoke
+// check expects a 2xx with a sensible body — return them so checks pass
+// (or skip naturally) and `runCli` reaches the no-AWS-SDK assertion.
+function setUpFetchMock(): void {
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (urlString.includes('/healthcheck')) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (urlString.includes('/proxy/library/search') || urlString.includes('/library/?artist_name')) {
+      return new Response(
+        JSON.stringify(urlString.includes('/proxy/') ? { results: [], total: 0, query: 'x' } : [{ id: 1 }]),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+    if (urlString.includes('/flowsheet')) {
+      return new Response('[]', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (urlString.includes('/api/v1/lookup')) {
+      // First call: good bearer → 200. Second call: known-bad bearer → 401.
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (urlString.includes('/sign-in/email') || urlString.includes('/token')) {
+      return new Response(JSON.stringify({ token: 'fake-jwt', user: { id: 'fake-id' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(`unmatched ${urlString}`, { status: 599 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+const baseArgv = [
+  'check',
+  '--base-url=https://bs-staging.example.test',
+  '--auth-url=https://bs-staging.example.test/auth',
+  '--lml-url=https://lml-staging.example.test',
+  '--suite=smoke',
+];
+
+beforeEach(() => {
+  cloudWatchCtorSpy.mockReset();
+  ssmCtorSpy.mockReset();
+  secretsManagerCtorSpy.mockReset();
+  setUpFetchMock();
+});
+
+describe('cli — AWS SDK isolation under polluted env (real runCanary)', () => {
+  it('does not instantiate SecretsManagerClient when CANARY_DJ_SECRET_ARN is set', async () => {
+    const { io } = setUpStreams();
+    await runCli(
+      baseArgv,
+      {
+        // The exact env-var that previously routed through to SDK
+        // instantiation via the fallback inside resolveDjCredentials.
+        CANARY_DJ_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:000:secret:dj/creds',
+        // DJ creds intentionally unset so resolveDjCredentials would
+        // otherwise reach for the SecretArn fallback.
+      },
+      io
+    );
+    expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not instantiate SecretsManagerClient when CANARY_LML_API_KEY_SECRET_ARN is set', async () => {
+    const { io } = setUpStreams();
+    await runCli(
+      baseArgv,
+      {
+        CANARY_LML_API_KEY_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:000:secret:lml/key',
+      },
+      io
+    );
+    expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not instantiate SSMClient when CANARY_GHA_RUNNER_TOKEN_SSM_PARAM is set', async () => {
+    const { io } = setUpStreams();
+    await runCli(
+      baseArgv,
+      {
+        CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/wxyc-canary/should-be-stripped',
+      },
+      io
+    );
+    expect(ssmCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not instantiate CloudWatchClient even with publishMetrics flag externally suggested', async () => {
+    // publishMetrics is controlled by config (hard-off in cli.ts), not
+    // env — but a future bug that wired the env-var to override it
+    // would surface here.
+    const { io } = setUpStreams();
+    await runCli(baseArgv, { CANARY_PUBLISH_METRICS: 'true' }, io);
+    expect(cloudWatchCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it('all three SDK constructors stay quiet with the full polluted-env combo', async () => {
+    const { io } = setUpStreams();
+    await runCli(
+      baseArgv,
+      {
+        CANARY_DJ_SECRET_ARN: 'arn:should-not-fire',
+        CANARY_LML_API_KEY_SECRET_ARN: 'arn:should-not-fire',
+        CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/should-not-fire',
+        CANARY_GITHUB_TOKEN_SSM_PARAM: '/should-not-fire',
+        CANARY_PUBLISH_METRICS: 'true',
+        CANARY_LOCAL: 'true',
+      },
+      io
+    );
+    expect(cloudWatchCtorSpy).not.toHaveBeenCalled();
+    expect(ssmCtorSpy).not.toHaveBeenCalled();
+    expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/cli-aws-isolation.test.ts
+++ b/test/cli-aws-isolation.test.ts
@@ -1,16 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Real-runCanary AWS-SDK isolation test. The companion file `cli.test.ts`
 // mocks `runCanary` and so cannot exercise the SDK-resolver code path —
 // its AWS-SDK-constructor assertion was tautological. This file un-mocks
 // `runCanary` (does not call `vi.mock('../src/handler.js')` at all) and
-// feeds the CLI an env polluted with the exact secret-store pointers
-// that would normally cause `resolveDjCredentials` /
-// `resolveLmlApiKey` / `resolveGhaRunnerToken` to instantiate
-// SecretsManagerClient or SSMClient. If the CLI's env-sanitization
-// layer works as designed, none of those constructors should fire.
+// pollutes `process.env` directly with the secret-store pointers that
+// would normally cause `resolveDjCredentials` / `resolveLmlApiKey` /
+// `resolveGhaRunnerToken` to instantiate SecretsManagerClient or
+// SSMClient. The polluted env MUST go onto process.env (not just the
+// runCli `env` parameter) — if it only went into the runCli parameter,
+// then `runCanary`'s fallback `opts?.env ?? process.env` would pull from
+// a clean process.env and the test would pass even if the CLI's
+// sanitization layer were deleted.
 //
-// We mock fetch instead so the actual HTTP probes don't go out.
+// We mock fetch so the actual HTTP probes don't go out.
 
 const { cloudWatchCtorSpy, ssmCtorSpy, secretsManagerCtorSpy } = vi.hoisted(() => ({
   cloudWatchCtorSpy: vi.fn(),
@@ -112,79 +115,108 @@ const baseArgv = [
   '--suite=smoke',
 ];
 
+// Snapshot + restore process.env around each test so the polluted vars
+// don't leak between cases or to other test files. Vitest gives each
+// test a shared process, so beforeEach/afterEach discipline is the
+// difference between deterministic and order-dependent runs.
+const POLLUTED_VARS = [
+  'CANARY_DJ_SECRET_ARN',
+  'CANARY_LML_API_KEY_SECRET_ARN',
+  'CANARY_GHA_RUNNER_TOKEN_SSM_PARAM',
+  'CANARY_GITHUB_TOKEN_SSM_PARAM',
+  'CANARY_PUBLISH_METRICS',
+  'CANARY_LOCAL',
+] as const;
+
+function pollute(values: Partial<Record<(typeof POLLUTED_VARS)[number], string>>): void {
+  for (const [k, v] of Object.entries(values)) {
+    process.env[k] = v;
+  }
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+
 beforeEach(() => {
   cloudWatchCtorSpy.mockReset();
   ssmCtorSpy.mockReset();
   secretsManagerCtorSpy.mockReset();
   setUpFetchMock();
+  // Snapshot every var we might pollute so afterEach can restore.
+  for (const k of POLLUTED_VARS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
 });
 
-describe('cli — AWS SDK isolation under polluted env (real runCanary)', () => {
-  it('does not instantiate SecretsManagerClient when CANARY_DJ_SECRET_ARN is set', async () => {
+afterEach(() => {
+  for (const k of POLLUTED_VARS) {
+    if (savedEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = savedEnv[k];
+    }
+  }
+});
+
+describe('cli — AWS SDK isolation under polluted process.env (real runCanary)', () => {
+  it('does not instantiate SecretsManagerClient when CANARY_DJ_SECRET_ARN is in process.env', async () => {
+    pollute({ CANARY_DJ_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:000:secret:dj/creds' });
     const { io } = setUpStreams();
-    await runCli(
-      baseArgv,
-      {
-        // The exact env-var that previously routed through to SDK
-        // instantiation via the fallback inside resolveDjCredentials.
-        CANARY_DJ_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:000:secret:dj/creds',
-        // DJ creds intentionally unset so resolveDjCredentials would
-        // otherwise reach for the SecretArn fallback.
-      },
-      io
-    );
+    // Critical: we pass an empty `env` to runCli (matching the cli-entry
+    // wiring where env=process.env on the prod path). The CLI's
+    // sanitization layer must strip CANARY_DJ_SECRET_ARN before forwarding
+    // to runCanary. If sanitization were removed, runCanary's
+    // `opts?.env ?? process.env` would land on the polluted process.env
+    // and the spy WOULD fire — that's what makes this test load-bearing.
+    await runCli(baseArgv, process.env, io);
     expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
   });
 
-  it('does not instantiate SecretsManagerClient when CANARY_LML_API_KEY_SECRET_ARN is set', async () => {
+  it('does not instantiate SecretsManagerClient when CANARY_LML_API_KEY_SECRET_ARN is in process.env', async () => {
+    pollute({ CANARY_LML_API_KEY_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:000:secret:lml/key' });
     const { io } = setUpStreams();
-    await runCli(
-      baseArgv,
-      {
-        CANARY_LML_API_KEY_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:000:secret:lml/key',
-      },
-      io
-    );
+    await runCli(baseArgv, process.env, io);
     expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
   });
 
-  it('does not instantiate SSMClient when CANARY_GHA_RUNNER_TOKEN_SSM_PARAM is set', async () => {
+  it('does not instantiate SSMClient when CANARY_GHA_RUNNER_TOKEN_SSM_PARAM is in process.env', async () => {
+    pollute({ CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/wxyc-canary/should-be-stripped' });
     const { io } = setUpStreams();
-    await runCli(
-      baseArgv,
-      {
-        CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/wxyc-canary/should-be-stripped',
-      },
-      io
-    );
+    await runCli(baseArgv, process.env, io);
     expect(ssmCtorSpy).not.toHaveBeenCalled();
   });
 
   it('does not instantiate CloudWatchClient even with publishMetrics flag externally suggested', async () => {
-    // publishMetrics is controlled by config (hard-off in cli.ts), not
-    // env — but a future bug that wired the env-var to override it
-    // would surface here.
+    pollute({ CANARY_PUBLISH_METRICS: 'true' });
     const { io } = setUpStreams();
-    await runCli(baseArgv, { CANARY_PUBLISH_METRICS: 'true' }, io);
+    await runCli(baseArgv, process.env, io);
     expect(cloudWatchCtorSpy).not.toHaveBeenCalled();
   });
 
   it('all three SDK constructors stay quiet with the full polluted-env combo', async () => {
+    pollute({
+      CANARY_DJ_SECRET_ARN: 'arn:should-not-fire',
+      CANARY_LML_API_KEY_SECRET_ARN: 'arn:should-not-fire',
+      CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/should-not-fire',
+      CANARY_GITHUB_TOKEN_SSM_PARAM: '/should-not-fire',
+      CANARY_PUBLISH_METRICS: 'true',
+      CANARY_LOCAL: 'true',
+    });
     const { io } = setUpStreams();
-    await runCli(
-      baseArgv,
-      {
-        CANARY_DJ_SECRET_ARN: 'arn:should-not-fire',
-        CANARY_LML_API_KEY_SECRET_ARN: 'arn:should-not-fire',
-        CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/should-not-fire',
-        CANARY_GITHUB_TOKEN_SSM_PARAM: '/should-not-fire',
-        CANARY_PUBLISH_METRICS: 'true',
-        CANARY_LOCAL: 'true',
-      },
-      io
-    );
+    await runCli(baseArgv, process.env, io);
     expect(cloudWatchCtorSpy).not.toHaveBeenCalled();
     expect(ssmCtorSpy).not.toHaveBeenCalled();
     expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate the operator-supplied env object (CLI builds a fresh sanitizedEnv)', async () => {
+    pollute({ CANARY_DJ_SECRET_ARN: 'arn:should-not-fire' });
+    const snapshot = { ...process.env };
+    const { io } = setUpStreams();
+    await runCli(baseArgv, process.env, io);
+    // The CLI must not delete/overwrite keys on the operator's env;
+    // a `delete env.X`-style sanitization would corrupt process.env
+    // for the rest of the process lifetime.
+    expect(process.env.CANARY_DJ_SECRET_ARN).toBe(snapshot.CANARY_DJ_SECRET_ARN);
   });
 });

--- a/test/cli-aws-isolation.test.ts
+++ b/test/cli-aws-isolation.test.ts
@@ -119,16 +119,37 @@ const baseArgv = [
 // don't leak between cases or to other test files. Vitest gives each
 // test a shared process, so beforeEach/afterEach discipline is the
 // difference between deterministic and order-dependent runs.
-const POLLUTED_VARS = [
+//
+// Snapshot the full CANARY_* surface (not just the *_SECRET_ARN /
+// *_SSM_PARAM keys we pollute) so any CI-set CANARY_DJ_EMAIL etc.
+// doesn't leak through `runCli(baseArgv, process.env, io)`. Otherwise
+// a real DJ login would attempt against the mock'd fetch and a future
+// refactor that moved an AWS-SDK call behind the signin/lml-auth path
+// would surface flakes only in CI.
+const SNAPSHOTTED_VARS = [
+  // Polluted directly by each test:
   'CANARY_DJ_SECRET_ARN',
   'CANARY_LML_API_KEY_SECRET_ARN',
   'CANARY_GHA_RUNNER_TOKEN_SSM_PARAM',
   'CANARY_GITHUB_TOKEN_SSM_PARAM',
   'CANARY_PUBLISH_METRICS',
   'CANARY_LOCAL',
+  // Cleared so a CI-set value doesn't reach runCli:
+  'CANARY_DJ_EMAIL',
+  'CANARY_DJ_PASSWORD',
+  'CANARY_LML_API_KEY',
+  'CANARY_ORIGIN_URL',
 ] as const;
 
-function pollute(values: Partial<Record<(typeof POLLUTED_VARS)[number], string>>): void {
+type PollutableVar =
+  | 'CANARY_DJ_SECRET_ARN'
+  | 'CANARY_LML_API_KEY_SECRET_ARN'
+  | 'CANARY_GHA_RUNNER_TOKEN_SSM_PARAM'
+  | 'CANARY_GITHUB_TOKEN_SSM_PARAM'
+  | 'CANARY_PUBLISH_METRICS'
+  | 'CANARY_LOCAL';
+
+function pollute(values: Partial<Record<PollutableVar, string>>): void {
   for (const [k, v] of Object.entries(values)) {
     process.env[k] = v;
   }
@@ -141,15 +162,17 @@ beforeEach(() => {
   ssmCtorSpy.mockReset();
   secretsManagerCtorSpy.mockReset();
   setUpFetchMock();
-  // Snapshot every var we might pollute so afterEach can restore.
-  for (const k of POLLUTED_VARS) {
+  // Snapshot + clear every CANARY_* var the CLI might react to, so
+  // each test starts from a known-clean env regardless of what the CI
+  // runner or other test files set.
+  for (const k of SNAPSHOTTED_VARS) {
     savedEnv[k] = process.env[k];
     delete process.env[k];
   }
 });
 
 afterEach(() => {
-  for (const k of POLLUTED_VARS) {
+  for (const k of SNAPSHOTTED_VARS) {
     if (savedEnv[k] === undefined) {
       delete process.env[k];
     } else {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -349,6 +349,68 @@ describe('runCli — argument validation', () => {
     expect(runCanaryMock).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts both DJ vars UNSET (no XOR, degrades to skipped — regression guard)', async () => {
+    // Critical regression case: the XOR check must NOT catch
+    // "both unset" — that case has to flow through to runCanary and
+    // become SKIPPED outcomes for the DJ-auth checks. A misshape that
+    // catches both-unset would block every CLI invocation that omits
+    // DJ creds (the dj-site staging-gate use case, where the gate
+    // tests against BS prod without DJ login).
+    const { io } = setUpStreams();
+    const code = await runCli(baseArgv, {}, io);
+    expect(code).toBe(0);
+    expect(runCanaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats whitespace-only DJ creds as unset (CI-substitution footgun)', async () => {
+    // Operator's GHA secret expands to empty string, gets quoted as ' '
+    // by shell — the value is truthy as a JS string but logically unset.
+    // Without `.trim()`, the XOR gate passes and signInDj fires with
+    // garbage credentials.
+    const { io, stderr } = setUpStreams();
+    const code = await runCli(baseArgv, { CANARY_DJ_EMAIL: ' ', CANARY_DJ_PASSWORD: 'real-password' }, io);
+    expect(code).toBe(2);
+    expect(stderr.join('')).toContain('must be set together');
+  });
+
+  it('rejects whitespace-only flag values (--base-url=" ")', async () => {
+    // Same shape: shell variable substitution or yaml-folded value
+    // expanding to whitespace. Without `.trim()`, the truthy-string
+    // check passes and the whitespace propagates into backendUrl,
+    // surfacing later as a cryptic "Invalid URL" error from
+    // canaryFetch instead of the clean exit-2 missing-flag contract.
+    const argv = [
+      'check',
+      '--base-url= ',
+      '--auth-url=https://x.test/auth',
+      '--lml-url=https://x.test',
+      '--suite=smoke',
+    ];
+    const { io, stderr } = setUpStreams();
+    const code = await runCli(argv, {}, io);
+    expect(code).toBe(2);
+    expect(stderr.join('')).toContain('--base-url');
+    expect(stderr.join('')).toContain('missing required flag');
+  });
+
+  it('sanitizeForLog neutralizes U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR', async () => {
+    // ASCII \\n is the obvious vector but JS/JSON-aware log parsers also
+    // treat U+2028 / U+2029 as line breaks. The sanitizer must catch
+    // them or the same injection forgery returns via Unicode.
+    const injected = `rejected suite=smoke passed=5 failed=0 skipped=0 fake`;
+    runCanaryMock.mockResolvedValueOnce([{ name: 'lml-auth', status: 'fail', latencyMs: 78, message: injected }]);
+    const { io, stderr } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    const joined = stderr.join('');
+    // The forged headline must NOT appear at the start of any line.
+    const lines = joined.split('\n');
+    expect(lines.some((l) => /^suite=smoke passed=5/.test(l))).toBe(false);
+    // The original text still appears (replaced with spaces, not deleted) —
+    // regression guard that sanitization didn't accidentally swallow the message.
+    expect(joined).toContain('rejected');
+    expect(joined).toContain('fake');
+  });
+
   it('--help mixed with unknown flag exits 2 (parseArgs runs before --help short-circuit)', async () => {
     // The bug this guards against: a previous implementation matched
     // `argv.includes('--help')` BEFORE parseArgs, so any combination of

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -397,16 +397,22 @@ describe('runCli — argument validation', () => {
     // ASCII \\n is the obvious vector but JS/JSON-aware log parsers also
     // treat U+2028 / U+2029 as line breaks. The sanitizer must catch
     // them or the same injection forgery returns via Unicode.
-    const injected = `rejected suite=smoke passed=5 failed=0 skipped=0 fake`;
+    //
+    // Assert directly on the absence of the offending code points in
+    // stderr — NOT on `split('\\n')`, which doesn't split on
+    // U+2028/U+2029 and would pass even if the regex didn't cover them.
+    const injected = `rejected\u2028suite=smoke passed=5 failed=0 skipped=0\u2029fake`;
     runCanaryMock.mockResolvedValueOnce([{ name: 'lml-auth', status: 'fail', latencyMs: 78, message: injected }]);
     const { io, stderr } = setUpStreams();
     await runCli(baseArgv, {}, io);
     const joined = stderr.join('');
-    // The forged headline must NOT appear at the start of any line.
-    const lines = joined.split('\n');
-    expect(lines.some((l) => /^suite=smoke passed=5/.test(l))).toBe(false);
-    // The original text still appears (replaced with spaces, not deleted) —
-    // regression guard that sanitization didn't accidentally swallow the message.
+    // Direct assertion: the offending code points must not survive the
+    // sanitizer. A regression that drops \\u2028/\\u2029 from the regex
+    // would fail here regardless of how stderr is split.
+    expect(joined).not.toContain('\u2028');
+    expect(joined).not.toContain('\u2029');
+    // Original text still appears (replaced with spaces, not deleted) —
+    // regression guard that sanitization didn't swallow the message.
     expect(joined).toContain('rejected');
     expect(joined).toContain('fake');
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -100,7 +100,11 @@ describe('runCli — happy paths', () => {
     const code = await runCli(baseArgv, {}, io);
     expect(code).toBe(0);
     expect(stdout.length).toBeGreaterThan(0);
-    expect(stderr.join('')).toContain('passed');
+    // Asserting the substring 'passed' alone is a wrong-thing test — the
+    // headline format `passed=N failed=N skipped=N` always contains
+    // 'passed' regardless of which counter is which. Pin the exact
+    // count + label so a future bug that swaps passed/failed gets caught.
+    expect(stderr.join('')).toContain('passed=3 failed=0 skipped=2');
   });
 
   it('emits one JSON line on stdout matching the contract shape', async () => {
@@ -171,12 +175,85 @@ describe('runCli — happy paths', () => {
     });
   });
 
-  it('does not instantiate any AWS SDK client', async () => {
+  // Note: the real "does not instantiate any AWS SDK client" assertion
+  // lives in `test/cli-aws-isolation.test.ts`, which un-mocks
+  // `runCanary` and feeds polluted env vars to verify the CLI's
+  // env-sanitization layer actually short-circuits the AWS SDK
+  // resolvers in handler.ts. The constructor spies below catch only the
+  // already-trivial case where `runCanary` is mocked away.
+  it('does not instantiate any AWS SDK client (cli.ts layer; full check in cli-aws-isolation.test.ts)', async () => {
     const { io } = setUpStreams();
     await runCli(baseArgv, {}, io);
     expect(cloudWatchCtorSpy).not.toHaveBeenCalled();
     expect(ssmCtorSpy).not.toHaveBeenCalled();
     expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it('projects outcomes to the documented contract — strips undocumented metrics field', async () => {
+    runCanaryMock.mockResolvedValueOnce([
+      // CheckOutcome supports a `metrics` field that the Lambda emits;
+      // the CLI's documented stdout contract does NOT include it.
+      {
+        name: 'enrichment-quality',
+        status: 'pass',
+        latencyMs: 12,
+        metrics: { EnrichmentLagSeconds: 5.4 },
+      },
+    ]);
+    const { io, stdout } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    const parsed = JSON.parse(stdout.join('').trim());
+    expect(parsed.outcomes[0]).toEqual({ name: 'enrichment-quality', status: 'pass', latencyMs: 12 });
+    expect(parsed.outcomes[0]).not.toHaveProperty('metrics');
+  });
+
+  it('sanitizes control characters in outcome.message before stderr write (log-injection defense)', async () => {
+    runCanaryMock.mockResolvedValueOnce([
+      // Attacker-controlled response body that leaked into a check
+      // error message could otherwise inject newlines and forge a
+      // misleading "passed=5 failed=0" trailer in the workflow log.
+      {
+        name: 'lml-auth',
+        status: 'fail',
+        latencyMs: 78,
+        message: 'rejected\nsuite=smoke passed=5 failed=0 skipped=0\nfake',
+      },
+    ]);
+    const { io, stderr } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    const joined = stderr.join('');
+    // The newlines in the injected message must be neutralized — no
+    // line in the summary should begin with the forged headline.
+    const lines = joined.split('\n');
+    // The headline line is the real one; subsequent lines should be the
+    // per-failure entries with the injected newline replaced by space.
+    expect(lines[0]).toBe('suite=smoke passed=0 failed=1 skipped=0');
+    expect(lines.some((l) => /^suite=smoke passed=5/.test(l))).toBe(false);
+  });
+
+  it('passes a sanitized env to runCanary so the SecretsManager fallback can never fire', async () => {
+    const pollutedEnv: NodeJS.ProcessEnv = {
+      CANARY_DJ_EMAIL: 'canary@wxyc.org',
+      CANARY_DJ_PASSWORD: 'sekret',
+      CANARY_LML_API_KEY: 'lml-bearer',
+      // The values below MUST be stripped before runCanary sees them.
+      CANARY_DJ_SECRET_ARN: 'arn:aws:secretsmanager:should-be-stripped',
+      CANARY_LML_API_KEY_SECRET_ARN: 'arn:aws:secretsmanager:should-be-stripped',
+      CANARY_GHA_RUNNER_TOKEN_SSM_PARAM: '/wxyc-canary/should-be-stripped',
+    };
+    const { io } = setUpStreams();
+    await runCli(baseArgv, pollutedEnv, io);
+    const [, opts] = runCanaryMock.mock.calls[0];
+    expect(opts?.env).toEqual({
+      CANARY_DJ_EMAIL: 'canary@wxyc.org',
+      CANARY_DJ_PASSWORD: 'sekret',
+      CANARY_LML_API_KEY: 'lml-bearer',
+      CANARY_ORIGIN_URL: undefined,
+    });
+    // The polluted vars are NOT in opts.env.
+    expect(opts?.env).not.toHaveProperty('CANARY_DJ_SECRET_ARN');
+    expect(opts?.env).not.toHaveProperty('CANARY_LML_API_KEY_SECRET_ARN');
+    expect(opts?.env).not.toHaveProperty('CANARY_GHA_RUNNER_TOKEN_SSM_PARAM');
   });
 });
 
@@ -218,7 +295,7 @@ describe('runCli — failure mapping', () => {
 });
 
 describe('runCli — argument validation', () => {
-  it('exits 2 on unknown --suite with a message listing valid suites', async () => {
+  it('exits 2 on unknown --suite with a message listing valid suites + USAGE', async () => {
     const argv = [
       'check',
       '--base-url=https://x.test',
@@ -232,6 +309,57 @@ describe('runCli — argument validation', () => {
     const msg = stderr.join('');
     expect(msg).toContain('bogus');
     expect(msg).toContain('smoke');
+    // Every other exit-2 path prints USAGE for operator orientation —
+    // the unknown-suite path should too.
+    expect(msg).toContain('wxyc-canary check');
+  });
+
+  it('exits 2 on extra positional arguments after the subcommand', async () => {
+    // parseArgs `strict: true` rejects unknown flags but not stray
+    // positionals — `wxyc-canary check smoek --suite=smoke` (operator
+    // typoed the suite as a positional) would otherwise silently ignore
+    // 'smoek' and run the suite passed via the flag.
+    const argv = [...baseArgv, 'leftover-positional'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toContain('leftover-positional');
+  });
+
+  it('exits 2 when CANARY_DJ_EMAIL is set without CANARY_DJ_PASSWORD', async () => {
+    // The XOR case silently degraded to "skipped" before this check
+    // existed: the gate would run green, with operators never learning
+    // their DJ-auth checks had been quietly skipped.
+    const { io, stderr } = setUpStreams();
+    const code = await runCli(baseArgv, { CANARY_DJ_EMAIL: 'canary@wxyc.org' }, io);
+    expect(code).toBe(2);
+    expect(stderr.join('')).toContain('CANARY_DJ_EMAIL and CANARY_DJ_PASSWORD must be set together');
+    expect(runCanaryMock).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when CANARY_DJ_PASSWORD is set without CANARY_DJ_EMAIL', async () => {
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(baseArgv, { CANARY_DJ_PASSWORD: 'sekret' }, io)).toBe(2);
+    expect(stderr.join('')).toContain('must be set together');
+  });
+
+  it('accepts both DJ vars set together', async () => {
+    const { io } = setUpStreams();
+    const code = await runCli(baseArgv, { CANARY_DJ_EMAIL: 'canary@wxyc.org', CANARY_DJ_PASSWORD: 'sekret' }, io);
+    expect(code).toBe(0);
+    expect(runCanaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('--help mixed with unknown flag exits 2 (parseArgs runs before --help short-circuit)', async () => {
+    // The bug this guards against: a previous implementation matched
+    // `argv.includes('--help')` BEFORE parseArgs, so any combination of
+    // bad flags + --help exited 0 silently. An automated tooling pass
+    // that uses --help to validate a flag set would think the typo
+    // was valid.
+    const argv = ['check', '--help', '--bogus-flag'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toMatch(/--bogus-flag|unknown/i);
+    expect(runCanaryMock).not.toHaveBeenCalled();
   });
 
   it('exits 2 when --base-url is missing', async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { runCanary as runCanaryType } from '../src/handler.js';
+
+// Mock runCanary so the CLI tests can drive it deterministically. The
+// suite-filter end-to-end test lives in `test/checks.test.ts`; here we
+// verify the CLI's arg parsing, config assembly, exit-code logic, and
+// stdout/stderr discipline.
+const { runCanaryMock } = vi.hoisted(() => ({
+  // `vi.fn<typeof runCanaryType>()` types `.mock.calls[0]` as the
+  // tuple of runCanary's argument types — tests can then index into
+  // `[config, opts]` without TS narrowing it to `never`.
+  runCanaryMock: vi.fn() as ReturnType<typeof vi.fn<typeof runCanaryType>>,
+}));
+vi.mock('../src/handler.js', () => ({
+  runCanary: runCanaryMock,
+}));
+
+// AWS SDK isolation: spy on every client constructor the codebase uses and
+// assert in the relevant test that none are instantiated when the CLI
+// runs. Catches regressions where a future refactor wires AWS-SDK
+// resolution into the CLI path.
+const { cloudWatchCtorSpy, ssmCtorSpy, secretsManagerCtorSpy } = vi.hoisted(() => ({
+  cloudWatchCtorSpy: vi.fn(),
+  ssmCtorSpy: vi.fn(),
+  secretsManagerCtorSpy: vi.fn(),
+}));
+vi.mock('@aws-sdk/client-cloudwatch', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-cloudwatch')>('@aws-sdk/client-cloudwatch');
+  return {
+    ...actual,
+    CloudWatchClient: vi.fn().mockImplementation((...args: unknown[]) => {
+      cloudWatchCtorSpy(...args);
+      return { send: vi.fn(async () => ({})) };
+    }),
+  };
+});
+vi.mock('@aws-sdk/client-ssm', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-ssm')>('@aws-sdk/client-ssm');
+  return {
+    ...actual,
+    SSMClient: vi.fn().mockImplementation((...args: unknown[]) => {
+      ssmCtorSpy(...args);
+      return { send: vi.fn(async () => ({})) };
+    }),
+  };
+});
+vi.mock('@aws-sdk/client-secrets-manager', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-secrets-manager')>(
+    '@aws-sdk/client-secrets-manager'
+  );
+  return {
+    ...actual,
+    SecretsManagerClient: vi.fn().mockImplementation((...args: unknown[]) => {
+      secretsManagerCtorSpy(...args);
+      return { send: vi.fn(async () => ({})) };
+    }),
+  };
+});
+
+import { runCli, type CliStreams } from '../src/cli.js';
+
+function setUpStreams(): { io: CliStreams; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    io: {
+      stdout: (s) => stdout.push(s),
+      stderr: (s) => stderr.push(s),
+    },
+  };
+}
+
+const baseArgv = [
+  'check',
+  '--base-url=https://bs-staging.example.test',
+  '--auth-url=https://bs-staging.example.test/auth',
+  '--lml-url=https://lml-staging.example.test',
+  '--suite=smoke',
+];
+
+beforeEach(() => {
+  runCanaryMock.mockReset();
+  runCanaryMock.mockResolvedValue([
+    { name: 'backend-healthcheck', status: 'pass', latencyMs: 12 },
+    { name: 'proxy-library-search', status: 'pass', latencyMs: 45 },
+    { name: 'dj-library-search', status: 'skipped', latencyMs: 0, message: 'no DJ credentials configured' },
+    { name: 'dj-flowsheet-read', status: 'skipped', latencyMs: 0, message: 'no DJ credentials configured' },
+    { name: 'lml-auth', status: 'pass', latencyMs: 78 },
+  ]);
+  cloudWatchCtorSpy.mockReset();
+  ssmCtorSpy.mockReset();
+  secretsManagerCtorSpy.mockReset();
+});
+
+describe('runCli — happy paths', () => {
+  it('exits 0 when every check returns pass or skipped', async () => {
+    const { io, stdout, stderr } = setUpStreams();
+    const code = await runCli(baseArgv, {}, io);
+    expect(code).toBe(0);
+    expect(stdout.length).toBeGreaterThan(0);
+    expect(stderr.join('')).toContain('passed');
+  });
+
+  it('emits one JSON line on stdout matching the contract shape', async () => {
+    const { io, stdout } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    const joined = stdout.join('');
+    // exactly one JSON object, no trailing data after the closing brace+newline
+    const lines = joined.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed).toEqual({
+      suite: 'smoke',
+      passed: 3,
+      failed: 0,
+      skipped: 2,
+      outcomes: [
+        { name: 'backend-healthcheck', status: 'pass', latencyMs: 12 },
+        { name: 'proxy-library-search', status: 'pass', latencyMs: 45 },
+        { name: 'dj-library-search', status: 'skipped', latencyMs: 0, message: 'no DJ credentials configured' },
+        { name: 'dj-flowsheet-read', status: 'skipped', latencyMs: 0, message: 'no DJ credentials configured' },
+        { name: 'lml-auth', status: 'pass', latencyMs: 78 },
+      ],
+    });
+  });
+
+  it('threads CLI URLs into the CanaryConfig passed to runCanary', async () => {
+    const { io } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    expect(runCanaryMock).toHaveBeenCalledTimes(1);
+    const [config] = runCanaryMock.mock.calls[0];
+    expect(config).toMatchObject({
+      backendUrl: 'https://bs-staging.example.test',
+      authUrl: 'https://bs-staging.example.test/auth',
+      lmlUrl: 'https://lml-staging.example.test',
+      publishMetrics: false,
+    });
+  });
+
+  it('passes the smoke-filtered checks array to runCanary', async () => {
+    const { io } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    const [, opts] = runCanaryMock.mock.calls[0];
+    expect(opts?.checks?.map((c) => c.name)).toEqual([
+      'backend-healthcheck',
+      'proxy-library-search',
+      'dj-library-search',
+      'dj-flowsheet-read',
+      'lml-auth',
+    ]);
+  });
+
+  it('reads DJ credentials and LML bearer from env, not flags', async () => {
+    const { io } = setUpStreams();
+    await runCli(
+      baseArgv,
+      {
+        CANARY_DJ_EMAIL: 'canary@wxyc.org',
+        CANARY_DJ_PASSWORD: 'sekret',
+        CANARY_LML_API_KEY: 'lml-bearer',
+      },
+      io
+    );
+    const [config] = runCanaryMock.mock.calls[0];
+    expect(config).toMatchObject({
+      djEmail: 'canary@wxyc.org',
+      djPassword: 'sekret',
+      lmlApiKey: 'lml-bearer',
+    });
+  });
+
+  it('does not instantiate any AWS SDK client', async () => {
+    const { io } = setUpStreams();
+    await runCli(baseArgv, {}, io);
+    expect(cloudWatchCtorSpy).not.toHaveBeenCalled();
+    expect(ssmCtorSpy).not.toHaveBeenCalled();
+    expect(secretsManagerCtorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('runCli — failure mapping', () => {
+  it('exits 1 when any check returns fail', async () => {
+    runCanaryMock.mockResolvedValueOnce([
+      { name: 'backend-healthcheck', status: 'pass', latencyMs: 12 },
+      { name: 'lml-auth', status: 'fail', latencyMs: 78, message: 'LML rejected bearer with 401' },
+    ]);
+    const { io, stdout, stderr } = setUpStreams();
+    const code = await runCli(baseArgv, {}, io);
+    expect(code).toBe(1);
+    const parsed = JSON.parse(stdout.join('').trim());
+    expect(parsed.failed).toBe(1);
+    // Stderr summary must name the failing check so the runner log points
+    // an on-call at the surface, not just a count.
+    expect(stderr.join('')).toContain('lml-auth');
+  });
+
+  it('exits 1 even when only one of many checks fails', async () => {
+    runCanaryMock.mockResolvedValueOnce([
+      { name: 'backend-healthcheck', status: 'pass', latencyMs: 12 },
+      { name: 'proxy-library-search', status: 'pass', latencyMs: 45 },
+      { name: 'lml-auth', status: 'fail', latencyMs: 78, message: 'boom' },
+      { name: 'dj-library-search', status: 'pass', latencyMs: 30 },
+      { name: 'dj-flowsheet-read', status: 'pass', latencyMs: 22 },
+    ]);
+    const { io } = setUpStreams();
+    expect(await runCli(baseArgv, {}, io)).toBe(1);
+  });
+
+  it('skipped-only outcomes are still exit 0', async () => {
+    runCanaryMock.mockResolvedValueOnce([
+      { name: 'backend-healthcheck', status: 'skipped', latencyMs: 0, message: 'skipped' },
+    ]);
+    const { io } = setUpStreams();
+    expect(await runCli(baseArgv, {}, io)).toBe(0);
+  });
+});
+
+describe('runCli — argument validation', () => {
+  it('exits 2 on unknown --suite with a message listing valid suites', async () => {
+    const argv = [
+      'check',
+      '--base-url=https://x.test',
+      '--auth-url=https://x.test/auth',
+      '--lml-url=https://x.test',
+      '--suite=bogus',
+    ];
+    const { io, stderr } = setUpStreams();
+    const code = await runCli(argv, {}, io);
+    expect(code).toBe(2);
+    const msg = stderr.join('');
+    expect(msg).toContain('bogus');
+    expect(msg).toContain('smoke');
+  });
+
+  it('exits 2 when --base-url is missing', async () => {
+    const argv = ['check', '--auth-url=https://x.test/auth', '--lml-url=https://x.test', '--suite=smoke'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toContain('--base-url');
+  });
+
+  it('exits 2 when --auth-url is missing', async () => {
+    const argv = ['check', '--base-url=https://x.test', '--lml-url=https://x.test', '--suite=smoke'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toContain('--auth-url');
+  });
+
+  it('exits 2 when --lml-url is missing', async () => {
+    const argv = ['check', '--base-url=https://x.test', '--auth-url=https://x.test/auth', '--suite=smoke'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toContain('--lml-url');
+  });
+
+  it('exits 2 when --suite is missing', async () => {
+    const argv = ['check', '--base-url=https://x.test', '--auth-url=https://x.test/auth', '--lml-url=https://x.test'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toContain('--suite');
+  });
+
+  it('exits 2 on unknown subcommand', async () => {
+    const argv = ['banana', ...baseArgv.slice(1)];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('').toLowerCase()).toContain('banana');
+  });
+
+  it('exits 2 on unknown flag (e.g. --dj-email — credentials are env-only)', async () => {
+    const argv = [...baseArgv, '--dj-email=oops@wxyc.org'];
+    const { io, stderr } = setUpStreams();
+    expect(await runCli(argv, {}, io)).toBe(2);
+    expect(stderr.join('')).toMatch(/--dj-email|unknown/i);
+  });
+
+  it('--help exits 0, writes usage to stdout, nothing to stderr', async () => {
+    const { io, stdout, stderr } = setUpStreams();
+    expect(await runCli(['--help'], {}, io)).toBe(0);
+    expect(stdout.join('')).toMatch(/wxyc-canary check/i);
+    expect(stderr.join('')).toBe('');
+    // help path must not invoke runCanary
+    expect(runCanaryMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Packages the existing Lambda check code as a `wxyc-canary check` CLI so the [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80) staging-gate workflows can invoke the same probes against staging URLs. Phase 5a of the staging-gate epic; blocks phase 5 (wxyc-shared#166 bs-lml-gate coordinator).

- New `runCli(argv, env, io)` entry in `src/cli.ts` plus a thin `src/cli-entry.ts` for the bundle so the test path is import-side-effect-free.
- Introduces `Suite` union + `VALID_SUITES` + `checksForSuite(suite)`. The `smoke` suite includes `backend-healthcheck`, `proxy-library-search`, `dj-library-search`, `dj-flowsheet-read`, `lml-auth`. Lambda-only checks (`gha-runner-online`, `enrichment-quality`, `semantic-index-search`, `dj-rotation`, `dj-rotation-picker`) are unreachable from the CLI by design.
- `runCanary(config, opts?: { checks })` threads the suite filter through without changing the Lambda's behavior.
- CLI hard-codes `publishMetrics: false` and never reads any `*_SSM_PARAM` / `*_SECRET_ARN` env vars, so no AWS SDK client is ever instantiated. A constructor-spy test enforces that contract.
- Credentials are env-only (`CANARY_DJ_EMAIL/PASSWORD`, `CANARY_LML_API_KEY`); flags would leak into shell history and CI logs.
- Exit codes: 0 all pass/skipped, 1 any fail, 2 invocation error. Stdout is one JSON line, stderr a human summary.

## Test plan

- [x] `npm test` — 80 tests pass (54 existing handler + 9 existing github-issues + 4 new checks-suite + 17 new CLI)
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — produces 37.7kb `dist/cli.js` (ESM, shebang, executable)
- [x] End-to-end smoke against prod with no credentials: `node dist/cli.js check --base-url=https://api.wxyc.org --auth-url=https://api.wxyc.org/auth --lml-url=https://library-metadata-lookup-production.up.railway.app --suite=smoke` → 1 pass (backend-healthcheck, 383ms), 4 skipped (no creds), exit 0
- [x] Argument validation: missing flag / unknown suite / unknown flag / unknown subcommand each exit 2 with usage on stderr
- [x] `--help` exits 0 with usage on stdout

Closes #38