### PR TITLE
fix(pkg): prepare script so npm install from git URL builds dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "npm run build:lambda && npm run build:cli",
     "build:lambda": "esbuild src/handler.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/handler.js --external:aws-sdk",
     "build:cli": "esbuild src/cli-entry.ts --bundle --platform=node --target=node24 --format=esm --outfile=dist/cli.js --banner:js='#!/usr/bin/env node' --external:@aws-sdk/* --external:@smithy/* && chmod +x dist/cli.js",
+    "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #46.

## Summary

`bin.wxyc-canary` points at `dist/cli.js`, but `dist/` is gitignored. Without `prepare`, `npm install -g github:WXYC/wxyc-canary#<sha>` installs the package metadata + creates the bin symlink but never builds dist, so the symlink resolves to nothing and the CLI exits with ENOENT.

The staging-gate workflow in [wxyc-shared#171](https://github.com/WXYC/wxyc-shared/pull/171) is the first consumer to install from a git URL and surfaced this. `prepare` runs the existing build chain automatically on git URL installs.

## Test plan

- [x] Local: `rm -rf node_modules dist && npm install` → produces `dist/cli.js` + `dist/handler.js`
- [x] `npm test` — 98/98 green
- [x] `node dist/cli.js --help` — prints usage
- [ ] After merge, wxyc-shared#171 bumps its pinned canary SHA to verify end-to-end `npm install -g github:WXYC/wxyc-canary#<this-sha>` produces a working binary.