### PR TITLE
Fix stale pagesOncall JSDoc (name semantic-index-freshness, not -search)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export type Check = {
    * `wxyc-canary-check-failure` alarm. Default true (fail-safe: a new check
    * pages until explicitly opted out). Set false ONLY for infra/CI probes
    * that are not DJ-facing surfaces — currently `gha-runner-online` and
-   * `semantic-index-search`. Explicit, type-checked, and deliberately NOT
+   * `semantic-index-freshness`. Explicit, type-checked, and deliberately NOT
    * derived from `suites`: the untagged `dj-rotation` / `dj-rotation-picker`
    * are user-facing and must keep the true default. Routes the failure into
    * the `UserFacingCheckFailure` (page) vs `InfraCheckFailure` (low-urgency)


### PR DESCRIPTION
Follow-up to #55. The `Check.pagesOncall` JSDoc in `src/types.ts` still listed the infra/non-paging probes as `gha-runner-online` and `semantic-index-search`, but #55 (closing #50) restored `semantic-index-search` to the user-facing paging tier. The two `pagesOncall: false` probes are now `gha-runner-online` and `semantic-index-freshness`.

This slipped through #55's doc sweep and its review loop because the keyword (`infra/CI probes`) and the stale check name sit on different lines of the comment, so the line-filtered grep skipped over it. The classification-pin tests and all other docs (`README.md`, `CLAUDE.md`, `docs/adding-a-check.md`, `template.yaml`, both test comment blocks, the source docstrings) were already correct.

Doc-only — no behavior, metric, or alarm change.

Local gate green: `build` / `format:check` / `typecheck` / `test` (114).