### PR TITLE
chore(oidc): flip probe redirect_uri default to .invalid TLD (BS#1584)

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -273,7 +273,7 @@ export async function runCanary(
     // empty `client_id` query param that better-auth rejects with
     // `invalid_client`. Same rule the runner-liveness fields use above.
     oidcProbeClientId: config.oidcProbeClientId || 'wxyc-canary',
-    oidcProbeRedirectUri: config.oidcProbeRedirectUri || 'https://canary.wxyc.org/authorize-echo',
+    oidcProbeRedirectUri: config.oidcProbeRedirectUri || 'https://canary.wxyc.invalid/authorize-echo',
   };
 
   const outcomes = await Promise.all(

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,6 @@ export type CanaryConfig = {
   ghaRunnerToken?: string;
   /** See CheckContext.oidcProbeClientId. Defaults to `'wxyc-canary'` in the handler. */
   oidcProbeClientId?: string;
-  /** See CheckContext.oidcProbeRedirectUri. Defaults to `'https://canary.wxyc.org/authorize-echo'` in the handler. */
+  /** See CheckContext.oidcProbeRedirectUri. Defaults to `'https://canary.wxyc.invalid/authorize-echo'` in the handler. */
   oidcProbeRedirectUri?: string;
 };

--- a/template.yaml
+++ b/template.yaml
@@ -138,15 +138,18 @@ Parameters:
       `??`, in src/handler.ts).
   OidcProbeRedirectUri:
     Type: String
-    Default: https://canary.wxyc.org/authorize-echo
+    Default: https://canary.wxyc.invalid/authorize-echo
     AllowedPattern: '^https?://.+'
     Description: >
       Redirect URI the `oidc-authorize` probe's trusted client is
       registered with. The URL never has to resolve — the check reads the
-      3xx `Location` with `redirect: 'manual'` and never follows it.
+      3xx `Location` with `redirect: 'manual'` and never follows it. Uses
+      the RFC 2606 `.invalid` TLD so a routing accident can never
+      exfiltrate authorization codes to a real host, and so the URL is
+      unambiguously non-resolving to future readers (BS#1584).
       The check asserts the returned Location matches this value on
       `origin` (strict compare — rejects prefix-crafted attacker URLs
-      like `https://canary.wxyc.org/authorize-echo-attacker.example.com`)
+      like `https://canary.wxyc.invalid/authorize-echo-attacker.example.com`)
       and on `pathname` after normalization: RFC 3986 §6.2.3 equivalence
       strips trailing slashes on both sides so `/authorize-echo`,
       `/authorize-echo/`, and `/authorize-echo//` all compare equal (a

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -3309,7 +3309,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         // R3-12: pin the outgoing request shape. The redirect URI here
         // is the bare-host form the test configures below.
         assertAuthorizeRequestShape(urlString, init, {
-          expectedRedirectUri: 'https://canary.wxyc.org/',
+          expectedRedirectUri: 'https://canary.wxyc.invalid/',
         });
         const url = new URL(urlString);
         const state = url.searchParams.get('state') ?? '';
@@ -3321,7 +3321,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
             // normalizePath contract rather than the pathological shape;
             // the important guarantee is that the strip doesn't collapse
             // `/` to empty and cause a non-root Location to match.
-            Location: `https://canary.wxyc.org//?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid//?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }
@@ -3355,7 +3355,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
       ...baseConfig,
       djEmail: 'canary@wxyc.org',
       djPassword: 'pw',
-      oidcProbeRedirectUri: 'https://canary.wxyc.org/',
+      oidcProbeRedirectUri: 'https://canary.wxyc.invalid/',
     });
     const oidc = outcomes.find((o) => o.name === 'oidc-authorize')!;
 
@@ -3367,7 +3367,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
     // the whole point of the probe (code + state parity live there). Node's
     // default fetch follows redirects, which would swallow the Location and
     // deliver whatever the redirect target returns (typically an ECONNREFUSED
-    // against the canary.wxyc.org placeholder callback). Pin the request-init.
+    // against the canary.wxyc.invalid placeholder callback). Pin the request-init.
     let capturedRedirect: RequestInit['redirect'] | undefined;
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -84,7 +84,7 @@ const AUTHORIZE_ECHO_STATE_STUB: StubEntry = {
       status: 302,
       body: '',
       headers: {
-        Location: `https://canary.wxyc.org/authorize-echo?code=canned-code&state=${encodeURIComponent(state)}`,
+        Location: `https://canary.wxyc.invalid/authorize-echo?code=canned-code&state=${encodeURIComponent(state)}`,
       },
     };
   },
@@ -113,7 +113,7 @@ function assertAuthorizeRequestShape(
   urlString: string,
   init: RequestInit | undefined,
   { expectedRedirectUri }: { expectedRedirectUri: string } = {
-    expectedRedirectUri: 'https://canary.wxyc.org/authorize-echo',
+    expectedRedirectUri: 'https://canary.wxyc.invalid/authorize-echo',
   }
 ) {
   const url = new URL(urlString);
@@ -2189,7 +2189,7 @@ function setUpEnrichmentHappyPathMock(): ReturnType<typeof setUpMethodAwareMock>
           status: 302,
           body: '',
           headers: {
-            Location: `https://canary.wxyc.org/authorize-echo?code=abcd1234&state=${encodeURIComponent(echoedState)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(echoedState)}`,
           },
         };
       },
@@ -2693,7 +2693,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         const url = new URL(urlString);
         expect(url.searchParams.get('response_type')).toBe('code');
         expect(url.searchParams.get('client_id')).toBe('wxyc-canary');
-        expect(url.searchParams.get('redirect_uri')).toBe('https://canary.wxyc.org/authorize-echo');
+        expect(url.searchParams.get('redirect_uri')).toBe('https://canary.wxyc.invalid/authorize-echo');
         const scope = url.searchParams.get('scope') ?? '';
         expect(scope).toMatch(/openid/);
         expect(scope).toMatch(/profile/);
@@ -2717,7 +2717,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         // this test rather than silently masking every 302-shape failure.
         expect(init?.redirect).toBe('manual');
         // Echo the state back to prove the state-parity check works.
-        const location = `https://canary.wxyc.org/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`;
+        const location = `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`;
         return new Response(null, {
           status: 302,
           headers: { Location: location },
@@ -2816,7 +2816,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
     setUpAuthorizeMock({
       status: 302,
       body: '',
-      headers: { Location: 'https://canary.wxyc.org/authorize-echo?state=some-state' },
+      headers: { Location: 'https://canary.wxyc.invalid/authorize-echo?state=some-state' },
     });
 
     const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
@@ -2840,7 +2840,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
       status: 302,
       body: '',
       headers: {
-        Location: 'https://canary.wxyc.org/authorize-echo#code=REAL-CODE-FRAG&state=X',
+        Location: 'https://canary.wxyc.invalid/authorize-echo#code=REAL-CODE-FRAG&state=X',
       },
     });
 
@@ -2862,7 +2862,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
       status: 302,
       body: '',
       headers: {
-        Location: 'https://canary.wxyc.org/authorize-echo?code=abcd1234&state=NOT-THE-STATE-WE-SENT',
+        Location: 'https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=NOT-THE-STATE-WE-SENT',
       },
     });
 
@@ -3073,7 +3073,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
     // string starts with the probe redirect URI but does NOT actually match
     // the registered client callback origin+path must fail. A naive
     // `startsWith` guard accepts:
-    //   https://canary.wxyc.org/authorize-echo-attacker.example.com/?code=X
+    //   https://canary.wxyc.invalid/authorize-echo-attacker.example.com/?code=X
     // as valid because the string prefix matches; strict URL parsing
     // (origin+pathname compare) rejects it. The mock echoes the state so
     // the state-mismatch guard doesn't shadow the URL check we're pinning.
@@ -3083,7 +3083,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         const url = new URL(urlString);
         const state = url.searchParams.get('state') ?? '';
         // Echo the state so this test isolates the URL check.
-        const location = `https://canary.wxyc.org/authorize-echo-attacker.example.com/?code=abcd1234&state=${encodeURIComponent(state)}`;
+        const location = `https://canary.wxyc.invalid/authorize-echo-attacker.example.com/?code=abcd1234&state=${encodeURIComponent(state)}`;
         return new Response(null, {
           status: 302,
           headers: { Location: location },
@@ -3145,7 +3145,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         return new Response(null, {
           status: 302,
           headers: {
-            Location: `https://canary.wxyc.org/authorize-echo/?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo/?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }
@@ -3191,14 +3191,14 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         // R3-12: pin the outgoing request shape. The `redirect_uri` here
         // is the trailing-slash form the test configures below.
         assertAuthorizeRequestShape(urlString, init, {
-          expectedRedirectUri: 'https://canary.wxyc.org/authorize-echo/',
+          expectedRedirectUri: 'https://canary.wxyc.invalid/authorize-echo/',
         });
         const url = new URL(urlString);
         const state = url.searchParams.get('state') ?? '';
         return new Response(null, {
           status: 302,
           headers: {
-            Location: `https://canary.wxyc.org/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }
@@ -3235,7 +3235,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
       ...baseConfig,
       djEmail: 'canary@wxyc.org',
       djPassword: 'pw',
-      oidcProbeRedirectUri: 'https://canary.wxyc.org/authorize-echo/',
+      oidcProbeRedirectUri: 'https://canary.wxyc.invalid/authorize-echo/',
     });
     const oidc = outcomes.find((o) => o.name === 'oidc-authorize')!;
 
@@ -3263,7 +3263,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
           headers: {
             // Doubled trailing slash — the shape a `base + '/' + path`
             // concatenation bug with a `/`-terminated base would emit.
-            Location: `https://canary.wxyc.org/authorize-echo//?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo//?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }
@@ -3378,7 +3378,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         return new Response(null, {
           status: 302,
           headers: {
-            Location: `https://canary.wxyc.org/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }
@@ -3430,7 +3430,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         return new Response(null, {
           status: 303,
           headers: {
-            Location: `https://canary.wxyc.org/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }
@@ -3543,7 +3543,7 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
         return new Response(null, {
           status: 302,
           headers: {
-            Location: `https://canary.wxyc.org/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
+            Location: `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`,
           },
         });
       }


### PR DESCRIPTION
## Summary

Coordinates with [WXYC/Backend-Service#1596](https://github.com/WXYC/Backend-Service/pull/1596) (which closes [BS#1584](https://github.com/WXYC/Backend-Service/issues/1584)): the `wxyc-canary` trusted-client's registered redirect URI is moving from `canary.wxyc.org/authorize-echo` to `canary.wxyc.invalid/authorize-echo` (RFC 2606 §2 reserved TLD — guaranteed non-resolving so a routing accident can never exfiltrate authorization codes to a real host, and unambiguously non-resolving to future readers).

For the check to keep passing after BS#1596 deploys, the canary's outbound `redirect_uri` query param on `/oauth2/authorize` must match the newly-registered value. This PR flips the defaults so it does.

## Changes

- `template.yaml`: `OidcProbeRedirectUri` default `.org` → `.invalid`; description extended with the RFC 2606 rationale and BS#1584 cross-reference.
- `src/handler.ts`: runtime `||` fallback default `.org` → `.invalid` (same shape as the `oidcProbeClientId` fallback right above it — empty env value picks up the default).
- `src/types.ts`: docstring for `CANARY_OIDC_PROBE_REDIRECT_URI` updated to match so IDE-hover doesn't drift.
- `test/handler.test.ts`: 18 test literals flipped `.org` → `.invalid` (mocked Location responses, expected `redirect_uri` assertions, and the prefix-bypass attacker base URL). Test invariants unchanged: origin+path guard still asserts the same behavior because attacker URL and configured URI share the new origin.

Behavioral / test guarantees: 140/140 tests still pass; `npm run typecheck` and `npm run format:check` both clean.

## Deploy sequence

1. Silence `wxyc-canary-check-failure` (the OIDC probe will page during the coordination window).
2. Merge this PR. Canary Lambda redeploys with `.invalid` as its declared `redirect_uri`. Since the auth server still has `.org` registered for `wxyc-canary`, the check pages for a few minutes with `authorize expected 302, got 400: invalid redirect_uri`.
3. Merge [BS#1596](https://github.com/WXYC/Backend-Service/pull/1596) immediately after. Auth container restarts with `.invalid` in the bootstrap. Next 5-minute canary tick returns to green.
4. Un-silence the alarm.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 140/140 pass (verified locally on `chore/canary-invalid-redirect-flip`)
- [ ] After merge + deploy sequence above, verify `oidc-authorize` check goes green in CloudWatch metrics within one 5-minute tick.