### PR TITLE
fix(oidc-authorize): accept better-auth's 200 {redirect,url} JSON shape

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -852,19 +852,52 @@ const oidcAuthorize: Check = {
         `authorize expected 302, got ${r.status} (BS#1571 replay class if body mentions oauthConsent): ${redactCodeAndState(r.rawText).slice(0, 200)}`
       );
     }
-    // OAuth 2.0 (RFC 6749 §4.1.2) allows either 302 Found or 303 See Other
-    // on the authorization response. better-auth returns 302 today, but the
-    // spec doesn't pin it — a future rev switching to 303 would be a
-    // legitimate change we must not flap on.
-    if (r.status !== 302 && r.status !== 303) {
+    // better-auth returns the authorize redirect in one of two shapes,
+    // chosen by `isBrowserFetchRequest()` (@better-auth/core fetch-metadata),
+    // which flips on `sec-fetch-mode: cors`:
+    //   - "browser" shape (JSON, HTTP 200): `{ redirect: true, url: '<redirect>' }`.
+    //     Node's undici sets `sec-fetch-mode: cors` automatically on server-side
+    //     `fetch()`, so the canary lands here today.
+    //   - "server" shape (HTTP 302/303 with `Location:` header). RFC 6749
+    //     §4.1.2 allows either 302 or 303; better-auth defaults to 302.
+    // Extract the redirect target from either shape into a single `location`
+    // string; downstream validation (origin+pathname compare, code presence,
+    // fragment guard) treats both identically because the underlying redirect
+    // URL is the same — it's only the transport that differs.
+    let location: string | undefined;
+    if (r.status === 302 || r.status === 303) {
+      location = r.headers?.location;
+      if (!location) {
+        // 3xx without a Location header is malformed. `canaryFetch` lowercases
+        // header names, so this covers `Location:` too.
+        throw new Error(`authorize returned ${r.status} with no Location header`);
+      }
+    } else if (r.status === 200) {
+      // Parse the JSON body defensively. A 200 with a non-JSON body OR a JSON
+      // body without `{redirect: true, url}` is a regression class distinct
+      // from a legit 302 — surface it as such so on-call routes to a
+      // better-auth response-shape investigation, not a login/session bounce.
+      let body: unknown;
+      try {
+        body = JSON.parse(r.rawText);
+      } catch {
+        throw new Error(
+          `authorize returned 200 with non-JSON body (expected 302 or {redirect,url}): ${redactCodeAndState(r.rawText).slice(0, 200)}`
+        );
+      }
+      if (
+        !body ||
+        typeof body !== 'object' ||
+        (body as { redirect?: unknown }).redirect !== true ||
+        typeof (body as { url?: unknown }).url !== 'string'
+      ) {
+        throw new Error(
+          `authorize returned 200 without the {redirect:true,url} shape better-auth uses on browser-fetch requests: ${redactCodeAndState(r.rawText).slice(0, 200)}`
+        );
+      }
+      location = (body as { url: string }).url;
+    } else {
       throw new Error(`authorize expected 302, got ${r.status}: ${redactCodeAndState(r.rawText).slice(0, 200)}`);
-    }
-
-    const location = r.headers?.location;
-    if (!location) {
-      // 3xx without a Location header is malformed. `canaryFetch` lowercases
-      // header names, so this covers `Location:` too.
-      throw new Error(`authorize returned ${r.status} with no Location header`);
     }
 
     let parsed: URL;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -3466,6 +3466,162 @@ describe('runCanary — oidc-authorize check (wxyc-canary#60)', () => {
     expect(oidc.status).toBe('pass');
   });
 
+  it('accepts the 200 {redirect,url} JSON shape better-auth uses when isBrowserFetchRequest fires (sec-fetch-mode: cors)', async () => {
+    // better-auth's authorize handler picks its response shape via
+    // `isBrowserFetchRequest()` (@better-auth/core/utils/fetch-metadata),
+    // which returns true when the request header set contains
+    // `sec-fetch-mode: cors`. Node's undici fetch attaches that header by
+    // default on server-side requests, so the canary lands on the JSON
+    // branch every tick against a live server:
+    //     HTTP/1.1 200 OK
+    //     Content-Type: application/json
+    //     {"redirect":true,"url":"<redirect_uri>?code=…&state=…"}
+    // rather than the 302 with `Location:` header the older tests mock.
+    // The check MUST unify both shapes because the underlying OAuth flow
+    // is identical — only the transport differs. This test pins the
+    // JSON-shape acceptance so a future refactor that regresses to
+    // "302-or-fail" flaps the alarm every tick against the real auth
+    // server. Related: canary#61 introduced the check assuming 302 only;
+    // real deploy of BS#1596 (auth wired for `.invalid` + `useJWTPlugin`)
+    // is what surfaced the mismatch, since prior probes never reached a
+    // success path.
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (urlString.includes('/oauth2/authorize')) {
+        const url = new URL(urlString);
+        const state = url.searchParams.get('state') ?? '';
+        const redirectUrl = `https://canary.wxyc.invalid/authorize-echo?code=abcd1234&state=${encodeURIComponent(state)}`;
+        return new Response(JSON.stringify({ redirect: true, url: redirectUrl }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const stubs: Record<string, { status: number; body: unknown }> = {
+        '/healthcheck': { status: 200, body: { ok: true } },
+        '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+        '/graph/artists/search': { status: 200, body: { results: [{ id: 1, canonical_name: 'stereolab' }] } },
+        'explore.example.test/health': {
+          status: 200,
+          body: { status: 'healthy', artist_count: 136_702, graph_db_age_seconds: 3_600 },
+        },
+        '/sign-in/email': { status: 200, body: { token: 'fake-session-token', user: { id: 'canary-user-id' } } },
+        '/token': { status: 200, body: { token: 'fake-jwt' } },
+        '/library/?artist_name=': { status: 200, body: stereolabSearchResults },
+        '/flowsheet': { status: 200, body: [] },
+        '/library/rotation': { status: 200, body: [] },
+      };
+      for (const [pattern, resp] of Object.entries(stubs)) {
+        if (urlString.includes(pattern)) {
+          return new Response(typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body), {
+            status: resp.status,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+      }
+      return new Response(`unmatched mock for ${urlString}`, { status: 599 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    const oidc = outcomes.find((o) => o.name === 'oidc-authorize')!;
+
+    expect(oidc.status).toBe('pass');
+  });
+
+  it('fails distinctly when authorize returns 200 with a non-JSON body (regression class differs from a legit 302)', async () => {
+    // A 200 with a body that isn't parseable JSON is a real regression
+    // class — likely a proxy/gateway HTML error page reaching the client
+    // as 200 (better-auth would surface its own errors as JSON). Route to
+    // its own message so on-call knows the auth server isn't returning
+    // either OAuth shape, rather than getting a generic "expected 302".
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (urlString.includes('/oauth2/authorize')) {
+        return new Response('<html><body>Gateway timeout</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        });
+      }
+      const stubs: Record<string, { status: number; body: unknown }> = {
+        '/healthcheck': { status: 200, body: { ok: true } },
+        '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+        '/graph/artists/search': { status: 200, body: { results: [{ id: 1, canonical_name: 'stereolab' }] } },
+        'explore.example.test/health': {
+          status: 200,
+          body: { status: 'healthy', artist_count: 136_702, graph_db_age_seconds: 3_600 },
+        },
+        '/sign-in/email': { status: 200, body: { token: 'fake-session-token', user: { id: 'canary-user-id' } } },
+        '/token': { status: 200, body: { token: 'fake-jwt' } },
+        '/library/?artist_name=': { status: 200, body: stereolabSearchResults },
+        '/flowsheet': { status: 200, body: [] },
+        '/library/rotation': { status: 200, body: [] },
+      };
+      for (const [pattern, resp] of Object.entries(stubs)) {
+        if (urlString.includes(pattern)) {
+          return new Response(typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body), {
+            status: resp.status,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+      }
+      return new Response(`unmatched mock for ${urlString}`, { status: 599 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    const oidc = outcomes.find((o) => o.name === 'oidc-authorize')!;
+
+    expect(oidc.status).toBe('fail');
+    expect(oidc.message).toMatch(/non-JSON body/);
+  });
+
+  it('fails distinctly when authorize returns 200 JSON without the {redirect,url} shape', async () => {
+    // JSON that parses but lacks the `redirect: true` + `url` fields is
+    // another distinct regression: better-auth reworking the response
+    // envelope, or a different endpoint handler catching the route. Route
+    // to its own message so on-call knows the shape drifted rather than
+    // the flow being missing.
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const urlString = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (urlString.includes('/oauth2/authorize')) {
+        return new Response(JSON.stringify({ success: true, note: 'no url here' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const stubs: Record<string, { status: number; body: unknown }> = {
+        '/healthcheck': { status: 200, body: { ok: true } },
+        '/proxy/library/search': { status: 200, body: proxyLibrarySearchResponse },
+        '/graph/artists/search': { status: 200, body: { results: [{ id: 1, canonical_name: 'stereolab' }] } },
+        'explore.example.test/health': {
+          status: 200,
+          body: { status: 'healthy', artist_count: 136_702, graph_db_age_seconds: 3_600 },
+        },
+        '/sign-in/email': { status: 200, body: { token: 'fake-session-token', user: { id: 'canary-user-id' } } },
+        '/token': { status: 200, body: { token: 'fake-jwt' } },
+        '/library/?artist_name=': { status: 200, body: stereolabSearchResults },
+        '/flowsheet': { status: 200, body: [] },
+        '/library/rotation': { status: 200, body: [] },
+      };
+      for (const [pattern, resp] of Object.entries(stubs)) {
+        if (urlString.includes(pattern)) {
+          return new Response(typeof resp.body === 'string' ? resp.body : JSON.stringify(resp.body), {
+            status: resp.status,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+      }
+      return new Response(`unmatched mock for ${urlString}`, { status: 599 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outcomes = await runCanary({ ...baseConfig, djEmail: 'canary@wxyc.org', djPassword: 'pw' });
+    const oidc = outcomes.find((o) => o.name === 'oidc-authorize')!;
+
+    expect(oidc.status).toBe('fail');
+    expect(oidc.message).toMatch(/\{redirect:true,url\}/);
+  });
+
   it('does NOT retry on a 500 from /oauth2/authorize (single tick → single call → single fail)', async () => {
     // The 429 precondition path retries once at the sign-in layer, but the
     // oidc-authorize check itself must not double-tap the auth server on a


### PR DESCRIPTION
## Summary

better-auth's authorize handler picks its response shape via `isBrowserFetchRequest()` (`@better-auth/core/utils/fetch-metadata`), which returns true when the request headers include `sec-fetch-mode: cors`. Node's undici fetch attaches that header by default on server-side requests, so the canary probe lands on the JSON branch every tick against a real auth server:

\`\`\`
HTTP/1.1 200 OK
Content-Type: application/json
{\"redirect\":true,\"url\":\"<redirect_uri>?code=...&state=...\"}
\`\`\`

not the 302 with \`Location:\` header the check was written for. Verified live via direct Lambda invocation post-BS#1596 + canary#70 + canary#72:

\`\`\`
oidc-authorize: authorize expected 302, got 200: {\"redirect\":true,\"url\":\"https://canary.wxyc.invalid/authorize-echo?code=<redacted>&state=<redacted>\"}
\`\`\`

The mismatch stayed invisible while auth was returning 400 (\`Invalid redirect URI\` during the pre-BS#1596 window and the pre-canary#72 CFN-stale-param window); as soon as BS#1596 registered the \`.invalid\` trusted client and canary#72 pushed \`.invalid\` into the Lambda env, the flow succeeded end-to-end and the check-side response-shape bug surfaced.

## Change

Unify the two shapes into a single \`location\` string, then run the same downstream validation (origin+pathname compare, code presence, state parity, fragment guard) that already existed for the 302 path — the underlying OAuth flow is identical, only the transport differs.

- 302 or 303 → read \`r.headers?.location\` (unchanged path).
- 200 → JSON-parse the body defensively; require \`{redirect: true, url: string}\`; extract \`url\` as \`location\`. A 200 with a non-JSON body OR a JSON body missing the shape gets its own distinct error message so on-call can route directly to a better-auth response-shape investigation rather than to a generic \"expected 302\".
- anything else → the existing \"expected 302, got N\" branch.

## Regression coverage

Three new tests in \`test/handler.test.ts\` inserted right after the 303-acceptance test:

- Happy path: mocks \`200 {redirect: true, url}\` and pins \`oidc.status === 'pass'\`.
- Non-JSON 200 body → distinct \"non-JSON body\" failure message.
- 200 JSON missing the shape → distinct \"{redirect:true,url} shape\" failure message.

Existing 302/303/500 tests are untouched — the shape branch is additive.

## Deploy sequence

1. Merge and wait for \`Deploy WXYC Canary\`.
2. Invoke the Lambda (or wait one 5-min tick) and confirm \`oidc-authorize\` flips to \`pass\`.
3. Re-enable \`wxyc-canary-check-failure\` alarm actions (disabled during the coordination window that started with the BS#1596 merge).

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run format:check\` clean
- [x] \`npm test\` — 143/143 pass (140 baseline + 3 new)
- [ ] After merge: \`oidc-authorize\` returns \`pass\` on next invocation
- [ ] All 12 checks pass; alarm re-enabled with actions