### PR TITLE
Move canary deploy to WXYC account via GitHub OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,12 @@ jobs:
           use-installer: true
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Assume the wxyc-canary-deploy role in the WXYC account (203767826763)
+          # via GitHub OIDC — no long-lived AWS keys are stored in the repo. The
+          # `permissions: id-token: write` block above mints the OIDC token; the
+          # role's trust policy is pinned to this repo's main ref. See
+          # bootstrap/deploy-role.yaml and README "CI deploys (GitHub OIDC)".
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
       - run: npm ci
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -278,17 +278,32 @@ When the runner is replaced (instance swap or re-registration), repeat step 3 an
 
 To turn the probe off, redeploy with an empty `GhaRunnerTokenSsmParamName` or `GhaRunnerId=0`. The conditional in `template.yaml` then strips the SSM IAM grant and the env vars; the check downgrades to `skipped` and the alarm stays quiet.
 
-### CI deploys
+### CI deploys (GitHub OIDC)
 
-`.github/workflows/deploy.yml` builds + deploys on push to `main`. Required GitHub secrets:
+`.github/workflows/deploy.yml` builds + deploys on push to `main`. It authenticates to the WXYC AWS account (`203767826763`) by assuming an IAM role via **GitHub OIDC — no long-lived AWS keys are stored in the repo**. The role's trust policy is pinned to `repo:WXYC/wxyc-canary:ref:refs/heads/main`, so only a push to `main` in this repo can assume it.
 
-- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` — same shape as Backend-Service
-- `DJ_CREDENTIALS_SECRET_ARN` — the ARN from step 2 above
+**One-time account bootstrap** (already applied to `203767826763`): deploy `bootstrap/deploy-role.yaml`, which creates the account-global GitHub OIDC provider and the least-privilege `wxyc-canary-deploy` role (scoped to `wxyc-canary*` resources + the SAM managed bucket):
 
-Required GitHub variables (override defaults if needed):
+```bash
+aws cloudformation deploy \
+  --template-file bootstrap/deploy-role.yaml \
+  --stack-name wxyc-canary-deploy \
+  --capabilities CAPABILITY_NAMED_IAM
+```
 
-- `BACKEND_URL`, `AUTH_URL`, `SEMANTIC_INDEX_URL`, `ALERT_EMAIL`
+Take the stack's `DeployRoleArn` output and set it as the `AWS_DEPLOY_ROLE_ARN` GitHub variable. The OIDC provider is account-global (unique per URL) — when a second WXYC repo adopts OIDC, move the provider into its own shared stack and leave only per-repo roles in each repo's bootstrap.
+
+Required GitHub variables:
+
+- `AWS_DEPLOY_ROLE_ARN` — the `wxyc-canary-deploy` role ARN from the bootstrap stack. The workflow's `permissions: id-token: write` block (already present) lets the runner mint the OIDC token; `configure-aws-credentials` exchanges it for short-lived role credentials.
+- `AWS_REGION` — `us-east-1`.
+- `BACKEND_URL`, `AUTH_URL`, `SEMANTIC_INDEX_URL`, `LML_URL`, `OIDC_PROBE_REDIRECT_URI`, `ALERT_EMAIL`
 - `INFRA_ALERT_EMAIL` — optional low-urgency recipient for `wxyc-canary-infra-degraded` (the infra/CI tier, wxyc-canary#48). Leave unset for console-only; set it to a filtered alias to get non-paging email. An empty value is an accepted gap, not a silent one.
+
+Required GitHub secrets:
+
+- `DJ_CREDENTIALS_SECRET_ARN` — ARN of the Secrets Manager secret holding the canary DJ login (from the one-time setup above).
+- `LML_API_KEY_SECRET_ARN` — ARN of the Secrets Manager secret holding the shared LML bearer. **Copied, never rotated** — the same value backs BS + rom + tubafrenzy (Railway's one-secret-one-value convention).
 
 Optional GitHub variables for the runner-liveness probe (when all three are set the next deploy enables `gha-runner-online`; leave unset to keep it skipped):
 

--- a/bootstrap/deploy-role.yaml
+++ b/bootstrap/deploy-role.yaml
@@ -45,7 +45,15 @@ Resources:
               - Sid: CfnStack
                 Effect: Allow
                 Action: cloudformation:*
-                Resource: !Sub arn:aws:cloudformation:us-east-1:${AWS::AccountId}:stack/wxyc-canary/*
+                Resource:
+                  - !Sub arn:aws:cloudformation:us-east-1:${AWS::AccountId}:stack/wxyc-canary/*
+                  # SAM deploys through a change set: CreateChangeSet authorizes
+                  # against the stack, but DescribeChangeSet/ExecuteChangeSet
+                  # authorize against the changeSet resource ARN — which can't be
+                  # scoped to a stack by ARN. Without this, the CI deploy creates
+                  # the changeset then fails AccessDenied polling its status.
+                  # Changesets are ephemeral, deploy-only artifacts.
+                  - !Sub arn:aws:cloudformation:us-east-1:${AWS::AccountId}:changeSet/*
               - Sid: CfnListDescribe # unscopable read actions SAM issues pre-changeset
                 Effect: Allow
                 Action: [cloudformation:ListStacks, cloudformation:ValidateTemplate]

--- a/bootstrap/deploy-role.yaml
+++ b/bootstrap/deploy-role.yaml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  GitHub Actions OIDC provider + least-privilege deploy role for the wxyc-canary
+  SAM stack. The OIDC provider is account-global — extract it to a shared stack
+  when a second WXYC repo adopts OIDC. Future tightening: split the deploy role
+  so it holds only cloudformation:* + iam:PassRole on a dedicated CFN service
+  role that carries the broad service perms below.
+
+Parameters:
+  GitHubOrg: { Type: String, Default: WXYC }
+  RepoName: { Type: String, Default: wxyc-canary }
+  SamManagedBucket:
+    Type: String
+    Default: aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi
+
+Resources:
+  GitHubOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList: [sts.amazonaws.com]
+      # STS no longer validates this thumbprint for the GitHub provider (JWKS is
+      # library-verified), but the property is still required by the resource.
+      ThumbprintList: ['ffffffffffffffffffffffffffffffffffffffff']
+
+  CanaryDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: wxyc-canary-deploy
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Federated: !Ref GitHubOidcProvider }
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepoName}:ref:refs/heads/main
+      Policies:
+        - PolicyName: wxyc-canary-sam-deploy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: CfnStack
+                Effect: Allow
+                Action: cloudformation:*
+                Resource: !Sub arn:aws:cloudformation:us-east-1:${AWS::AccountId}:stack/wxyc-canary/*
+              - Sid: CfnListDescribe # unscopable read actions SAM issues pre-changeset
+                Effect: Allow
+                Action: [cloudformation:ListStacks, cloudformation:ValidateTemplate]
+                Resource: '*'
+              - Sid: SamBucket
+                Effect: Allow
+                Action: [s3:PutObject, s3:GetObject, s3:ListBucket, s3:GetBucketLocation]
+                Resource:
+                  - !Sub arn:aws:s3:::${SamManagedBucket}
+                  - !Sub arn:aws:s3:::${SamManagedBucket}/*
+              - Sid: Lambda
+                Effect: Allow
+                Action: lambda:*
+                Resource: !Sub arn:aws:lambda:us-east-1:${AWS::AccountId}:function:wxyc-canary
+              - Sid: Scheduler
+                Effect: Allow
+                Action: events:*
+                Resource: !Sub arn:aws:events:us-east-1:${AWS::AccountId}:rule/wxyc-canary-*
+              - Sid: Sns
+                Effect: Allow
+                Action: sns:*
+                Resource:
+                  - !Sub arn:aws:sns:us-east-1:${AWS::AccountId}:wxyc-canary-alerts
+                  - !Sub arn:aws:sns:us-east-1:${AWS::AccountId}:wxyc-canary-infra-alerts
+              - Sid: Alarms
+                Effect: Allow
+                Action: [cloudwatch:PutMetricAlarm, cloudwatch:DeleteAlarms, cloudwatch:DescribeAlarms]
+                Resource: !Sub arn:aws:cloudwatch:us-east-1:${AWS::AccountId}:alarm:wxyc-canary-*
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  [
+                    logs:CreateLogGroup,
+                    logs:DeleteLogGroup,
+                    logs:PutRetentionPolicy,
+                    logs:DescribeLogGroups,
+                    logs:TagResource,
+                    logs:ListTagsForResource,
+                  ]
+                Resource: !Sub arn:aws:logs:us-east-1:${AWS::AccountId}:log-group:/aws/lambda/wxyc-canary:*
+              - Sid: ExecRoleLifecycle # SAM-generated Lambda exec role: wxyc-canary-CanaryFunctionRole-*
+                Effect: Allow
+                Action:
+                  [
+                    iam:CreateRole,
+                    iam:DeleteRole,
+                    iam:GetRole,
+                    iam:PassRole,
+                    iam:AttachRolePolicy,
+                    iam:DetachRolePolicy,
+                    iam:PutRolePolicy,
+                    iam:DeleteRolePolicy,
+                    iam:GetRolePolicy,
+                    iam:TagRole,
+                    iam:ListRolePolicies,
+                    iam:ListAttachedRolePolicies,
+                  ]
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/wxyc-canary-*
+
+Outputs:
+  DeployRoleArn:
+    Value: !GetAtt CanaryDeployRole.Arn


### PR DESCRIPTION
Cuts the canary deploy over from static personal-account AWS keys to GitHub OIDC role assumption in the WXYC account (`203767826763`).

## Changes

- `.github/workflows/deploy.yml`: replace `aws-access-key-id` / `aws-secret-access-key` inputs with `role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}`. The existing `permissions: id-token: write` block already satisfies OIDC; `audience` defaults to `sts.amazonaws.com`, matching the provider.
- `bootstrap/deploy-role.yaml` (new): one-time CloudFormation stack creating the account-global GitHub OIDC provider and the least-privilege `wxyc-canary-deploy` role, scoped to `wxyc-canary*` resources + the SAM managed bucket, trust-pinned to this repo`'s `main` ref.
- README "CI deploys" section rewritten for the OIDC path (bootstrap step, `AWS_DEPLOY_ROLE_ARN` variable, no stored keys).

## Deploy state (already applied out-of-band)

The WXYC-account stack was stood up manually and verified green (all 12 checks emitting, all alarms OK, both SNS subscriptions confirmed) while the personal canary kept running — no monitoring gap. The bootstrap stack + secrets are already in place, and the repo secrets/variables are updated so this merge`'s deploy resolves to a byte-identical parameter set, i.e. a no-op changeset that proves the OIDC path.

Personal-account teardown (stack + soft-deleted secrets) follows in a separate step after a clean cycle.

Closes #74