### PR TITLE
Fix CI deploy: use existing SAM bucket instead of resolve_s3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,12 +77,20 @@ jobs:
           if [ -n "$INFRA_ALERT_EMAIL" ]; then
             OPTIONAL_ARGS+=("InfraAlertEmail=$INFRA_ALERT_EMAIL")
           fi
+          # Use the existing SAM managed bucket explicitly rather than
+          # --resolve-s3. --resolve-s3 reconciles the `aws-sam-cli-managed-default`
+          # CloudFormation stack (CreateChangeSet against it) to ensure the bucket
+          # exists — but the least-privilege deploy role is scoped to
+          # stack/wxyc-canary/*, so that reconciliation is AccessDenied. The bucket
+          # already exists (created when the account was first SAM-bootstrapped);
+          # pointing at it directly skips the managed-stack step. The deploy role's
+          # SamBucket statement grants the needed s3:* on this bucket.
           sam deploy \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
             --stack-name wxyc-canary \
             --capabilities CAPABILITY_IAM \
-            --resolve-s3 \
+            --s3-bucket "${{ vars.SAM_S3_BUCKET || 'aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi' }}" \
             --parameter-overrides \
               BackendUrl=${{ vars.BACKEND_URL || 'https://api.wxyc.org' }} \
               AuthUrl=${{ vars.AUTH_URL || 'https://api.wxyc.org/auth' }} \

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -5,4 +5,8 @@ stack_name = "wxyc-canary"
 region = "us-east-1"
 capabilities = "CAPABILITY_IAM"
 confirm_changeset = false
-resolve_s3 = true
+# Use the existing SAM managed bucket directly instead of resolve_s3. resolve_s3
+# reconciles the aws-sam-cli-managed-default CFN stack, which the least-privilege
+# CI deploy role (scoped to stack/wxyc-canary/*) is not authorized to touch. The
+# CI workflow can override this bucket via the SAM_S3_BUCKET variable.
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi"


### PR DESCRIPTION
Follow-up to #75. After the OIDC cutover merged, the `deploy` job failed:

```
AccessDenied: User: arn:aws:sts::203767826763:assumed-role/wxyc-canary-deploy/GitHubActions
is not authorized to perform: cloudformation:CreateChangeSet on resource:
arn:aws:cloudformation:us-east-1:203767826763:stack/aws-sam-cli-managed-default/...
```

**Cause:** `--resolve-s3` does not merely reference the artifact bucket — it reconciles the `aws-sam-cli-managed-default` CloudFormation stack (a `CreateChangeSet` against it) to guarantee the bucket exists. The least-privilege deploy role is scoped to `stack/wxyc-canary/*`, so it is not authorized to touch the SAM bootstrap stack. The manual Phase 1 deploy masked this because it ran as an account admin. OIDC auth itself worked — the error is post-auth, and the assumed role in the ARN confirms it.

**Fix:** the managed bucket already exists from the account`'s original SAM bootstrap, so point SAM at it directly and skip the managed-stack reconciliation:
- `samconfig.toml`: replace `resolve_s3 = true` with `s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi"`.
- `.github/workflows/deploy.yml`: replace `--resolve-s3` with `--s3-bucket` (overridable via a `SAM_S3_BUCKET` variable). Removing `resolve_s3` from samconfig is required — otherwise `--s3-bucket` errors with "Cannot use both --resolve-s3 and --s3-bucket".

The deploy role`'s existing `SamBucket` statement already grants the needed S3 actions on this bucket.

**Validation:** `sam deploy --no-execute-changeset --s3-bucket ...` with the CI parameter set reports `No changes to deploy. Stack wxyc-canary is up to date`, so the post-merge CI deploy is a clean no-op. The canary stack was already stood up in Phase 1 and is running healthy, so there is no monitoring gap — only CI redeploy was blocked.

Related: #74, #75