### PR TITLE
Grant deploy role CreateChangeSet on the SAM transform

### DIFF
--- a/bootstrap/deploy-role.yaml
+++ b/bootstrap/deploy-role.yaml
@@ -58,6 +58,14 @@ Resources:
                 Effect: Allow
                 Action: [cloudformation:ListStacks, cloudformation:ValidateTemplate]
                 Resource: '*'
+              - Sid: SamTransform
+                # The template's `Transform: AWS::Serverless-2016-10-31` is expanded
+                # by this AWS-owned macro during CreateChangeSet; CloudFormation
+                # authorizes the expansion against the transform's own ARN (account
+                # segment is literally `aws`). Standard sam-pipeline-bootstrap grant.
+                Effect: Allow
+                Action: cloudformation:CreateChangeSet
+                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
               - Sid: SamBucket
                 Effect: Allow
                 Action: [s3:PutObject, s3:GetObject, s3:ListBucket, s3:GetBucketLocation]


### PR DESCRIPTION
Second follow-up to #75 / #76. After the `--s3-bucket` fix (#76), the CI deploy got past the managed-bucket stage and failed at the next layer:

```
AccessDenied: cloudformation:CreateChangeSet on resource:
arn:aws:cloudformation:us-east-1:aws:transform/Serverless-2016-10-31
```

**Cause:** the template declares `Transform: AWS::Serverless-2016-10-31`. CloudFormation expands that macro during `CreateChangeSet`, and authorizes the expansion against the transform`'s own AWS-owned ARN (account segment is literally `aws`) — separate from the stack ARN. This is exactly the grant `sam pipeline bootstrap` emits for its deploy role.

**Fix:** add a `SamTransform` statement granting `cloudformation:CreateChangeSet` on `arn:aws:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31`. With this, the role`'s CloudFormation permissions are a superset of AWS`'s reference SAM-deploy role (`cloudformation:*` on the stack + changeSet, plus the transform grant).

The live `wxyc-canary-deploy` role was already updated by redeploying the bootstrap stack, so merging this both records the change in source and re-triggers the deploy to validate end to end.

**Validation caveat:** IAM policy simulation can`'t adjudicate CreateChangeSet against AWS-owned resource ARNs (transform, changeSet) — it returns implicitDeny under any policy, including `Resource: *` — and the throwaway-role end-to-end test requires creating an IAM role. So the merge deploy is the validating run. The canary stack remains healthy from Phase 1; there is no monitoring gap, only CI redeploy was blocked.

Related: #74, #75, #76