### PR TITLE
docs: record discogs-etl as a second consumer of this stack's OIDC provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,13 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
-Take the stack's `DeployRoleArn` output and set it as the `AWS_DEPLOY_ROLE_ARN` GitHub variable. The OIDC provider is account-global (unique per URL) — when a second WXYC repo adopts OIDC, move the provider into its own shared stack and leave only per-repo roles in each repo's bootstrap.
+Take the stack's `DeployRoleArn` output and set it as the `AWS_DEPLOY_ROLE_ARN` GitHub variable.
+
+> **The OIDC provider is account-global (unique per URL) and this stack owns it. It now has a second consumer.** [`WXYC/discogs-etl`](https://github.com/WXYC/discogs-etl) adopted OIDC in this account on 2026-08-04 ([discogs-etl#353](https://github.com/WXYC/discogs-etl/issues/353)) and references the provider by ARN from its own `infra/bootstrap/deploy-role.yaml` rather than re-declaring it — a second `AWS::IAM::OIDCProvider` for the same URL fails with `EntityAlreadyExists`.
+>
+> Two consequences. **Deleting the `wxyc-canary-deploy` stack now breaks discogs-etl's CI deploy**, not just this repo's; the provider goes with it. And the "move the provider into its own shared stack" refactor below is no longer hypothetical work for a future repo — it is deferred work with a live cross-repo dependency. Doing it means updating discogs-etl's `OidcProviderArn` parameter in the same change.
+
+When a third WXYC repo adopts OIDC, move the provider into its own shared stack and leave only per-repo roles in each repo's bootstrap.
 
 Required GitHub variables:
 

--- a/bootstrap/deploy-role.yaml
+++ b/bootstrap/deploy-role.yaml
@@ -1,10 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   GitHub Actions OIDC provider + least-privilege deploy role for the wxyc-canary
-  SAM stack. The OIDC provider is account-global — extract it to a shared stack
-  when a second WXYC repo adopts OIDC. Future tightening: split the deploy role
-  so it holds only cloudformation:* + iam:PassRole on a dedicated CFN service
-  role that carries the broad service perms below.
+  SAM stack. The OIDC provider is account-global and this stack owns it; it now
+  has a second consumer, so deleting this stack breaks WXYC/discogs-etl's CI
+  deploy too (see the GitHubOidcProvider comment below). Future tightening:
+  split the deploy role so it holds only cloudformation:* + iam:PassRole on a
+  dedicated CFN service role that carries the broad service perms below.
 
 Parameters:
   GitHubOrg: { Type: String, Default: WXYC }
@@ -14,6 +15,15 @@ Parameters:
     Default: aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi
 
 Resources:
+  # Account-global and unique per URL, so exactly one stack in the account may
+  # declare it and that stack is this one. Consumers as of 2026-08-04:
+  #   - wxyc-canary          (this stack's CanaryDeployRole, below)
+  #   - WXYC/discogs-etl     infra/bootstrap/deploy-role.yaml, which takes the
+  #                          ARN as a parameter rather than re-declaring the
+  #                          resource (WXYC/discogs-etl#353)
+  # Deleting this stack therefore breaks discogs-etl's CI deploy, not only this
+  # repo's. Extracting the provider to a shared stack is still the right end
+  # state; it now requires a coordinated change in discogs-etl.
   GitHubOidcProvider:
     Type: AWS::IAM::OIDCProvider
     Properties:


### PR DESCRIPTION
Documentation only. No resource or policy changes; `validate-template` passes.

`bootstrap/deploy-role.yaml` and the README both described extracting the account-global OIDC provider to a shared stack as something to do *"when a second WXYC repo adopts OIDC."* That happened on 2026-08-04: [WXYC/discogs-etl](https://github.com/WXYC/discogs-etl) migrated its monthly-rebuild deploy into this account ([discogs-etl#353](https://github.com/WXYC/discogs-etl/issues/353)) and references the provider **by ARN** from its own `infra/bootstrap/deploy-role.yaml` rather than re-declaring it — a second `AWS::IAM::OIDCProvider` for the same URL fails `EntityAlreadyExists`.

The part worth writing down is not the refactor, it is the coupling:

- **Deleting the `wxyc-canary-deploy` stack now breaks discogs-etl's CI deploy.** The provider goes with it, and nothing in discogs-etl makes that discoverable.
- **The extraction is no longer speculative future work.** It is deferred work with a live cross-repo dependency — doing it means updating discogs-etl's `OidcProviderArn` parameter in the same change.

The "move it to a shared stack" guidance is kept, retargeted at a *third* adopter.

## Related

- [WXYC/discogs-etl#353](https://github.com/WXYC/discogs-etl/issues/353) — the migration that made this repo's provider load-bearing for another repo
- [WXYC/discogs-etl#352](https://github.com/WXYC/discogs-etl/issues/352) — the incident behind it