### PR TITLE
Name the sampler into the wxyc-canary* namespace the deploy role is scoped to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Read the relevant topic doc before doing work in that area.
 
 ## Stream listener sampler
 
-A second Lambda in this repo, `wxyc-stream-listener-sampler`, samples WXYC's Icecast concurrent-listener count into PostHog every 5 minutes. It is **audience measurement, not monitoring** — read [`docs/scope.md`](docs/scope.md) before touching it, because several of this repo's conventions deliberately invert for it (it retries, it owns no alarms, it publishes no CloudWatch metrics).
+A second Lambda in this repo, `wxyc-canary-stream-listener-sampler`, samples WXYC's Icecast concurrent-listener count into PostHog every 5 minutes. It is **audience measurement, not monitoring** — read [`docs/scope.md`](docs/scope.md) before touching it, because several of this repo's conventions deliberately invert for it (it retries, it owns no alarms, it publishes no CloudWatch metrics).
 
 - **Why the number matters.** Concurrent listeners are the streaming analogue of Nielsen's AQH (Average Quarter-Hour) persons, which makes it the one online metric comparable to a broadcast rating. Cume is deliberately NOT derived: Icecast counts connections, Nielsen counts people. Only AQH and total listening hours survive a broadcast-vs-stream comparison honestly.
 - **Cost is fixed by construction.** One HTTP GET and at most one PostHog event per invocation pins ingestion at 288 events/day regardless of traffic or how many mounts appear upstream. This invariant is the whole reason the design is one summary event per tick rather than one per mount — a per-mount shape would make a billing-relevant number depend on config we do not control, which is the shape that took org analytics dark on 2026-08-04. Treat any change that raises the event rate as a billing decision.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
+**Name new resources into the `wxyc-canary*` namespace.** The deploy role is least-privilege and scoped by name prefix — `function:wxyc-canary*`, `log-group:/aws/lambda/wxyc-canary*`, `role/wxyc-canary-*`, `rule/wxyc-canary-*`, `alarm:wxyc-canary-*`. A resource named outside that prefix cannot be created by CI: the deploy fails `AccessDenied` mid-changeset and CloudFormation rolls the whole stack back. That is what happened on the stream sampler's first deploy, when it was named `wxyc-stream-listener-sampler`. Adding a resource whose name does not start with `wxyc-canary` requires an out-of-band redeploy of this bootstrap stack with IAM-capable credentials — so prefer the prefix.
+
 Take the stack's `DeployRoleArn` output and set it as the `AWS_DEPLOY_ROLE_ARN` GitHub variable. The OIDC provider is account-global (unique per URL) — when a second WXYC repo adopts OIDC, move the provider into its own shared stack and leave only per-repo roles in each repo's bootstrap.
 
 Required GitHub variables:
@@ -419,7 +421,7 @@ Add a new entry to the `checks` array in `src/checks.ts`. The check name becomes
 
 ## Stream listener sampler
 
-A second Lambda in this stack, `wxyc-stream-listener-sampler`, records how many people are connected to WXYC's Icecast stream. It is **audience measurement, not monitoring**: it owns no alarms, publishes no CloudWatch metrics, and cannot page. See [`docs/scope.md`](docs/scope.md) for why it deliberately inverts several canary conventions.
+A second Lambda in this stack, `wxyc-canary-stream-listener-sampler`, records how many people are connected to WXYC's Icecast stream. It is **audience measurement, not monitoring**: it owns no alarms, publishes no CloudWatch metrics, and cannot page. See [`docs/scope.md`](docs/scope.md) for why it deliberately inverts several canary conventions.
 
 ### What it does
 

--- a/bootstrap/deploy-role.yaml
+++ b/bootstrap/deploy-role.yaml
@@ -75,7 +75,15 @@ Resources:
               - Sid: Lambda
                 Effect: Allow
                 Action: lambda:*
-                Resource: !Sub arn:aws:lambda:us-east-1:${AWS::AccountId}:function:wxyc-canary
+                # Prefix, not an exact ARN: this stack now deploys more than one
+                # function (the canary itself plus wxyc-canary-stream-listener-sampler),
+                # and an exact ARN meant adding a second function rolled the whole
+                # stack back on `lambda:GetFunction` AccessDenied. Every other
+                # name-scoped statement here (role/, rule/, alarm/) already uses
+                # the `wxyc-canary*` prefix the README documents; this aligns
+                # Lambda and Logs with it, so a future function in this stack does
+                # not require an out-of-band IAM deploy to land.
+                Resource: !Sub arn:aws:lambda:us-east-1:${AWS::AccountId}:function:wxyc-canary*
               - Sid: Scheduler
                 Effect: Allow
                 Action: events:*
@@ -101,7 +109,7 @@ Resources:
                     logs:TagResource,
                     logs:ListTagsForResource,
                   ]
-                Resource: !Sub arn:aws:logs:us-east-1:${AWS::AccountId}:log-group:/aws/lambda/wxyc-canary:*
+                Resource: !Sub arn:aws:logs:us-east-1:${AWS::AccountId}:log-group:/aws/lambda/wxyc-canary*:*
               - Sid: ExecRoleLifecycle # SAM-generated Lambda exec role: wxyc-canary-CanaryFunctionRole-*
                 Effect: Allow
                 Action:

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -6,7 +6,7 @@
 
 ## The stream listener sampler is not a canary
 
-`wxyc-stream-listener-sampler` shares this repo but is a different kind of job, and the distinction is load-bearing:
+`wxyc-canary-stream-listener-sampler` shares this repo but is a different kind of job, and the distinction is load-bearing:
 
 - **It measures an audience, it does not assert liveness.** It records how many people are connected to the WXYC Icecast mounts so that number can be compared against broadcast ratings. A low number is a fact about the audience, not a fault.
 - **It owns no alarms and publishes no CloudWatch metrics.** Its only outputs are a PostHog event and a log line. It can never page, and an alarm suppression can never silence it.

--- a/template.yaml
+++ b/template.yaml
@@ -404,7 +404,11 @@ Resources:
   StreamSamplerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: wxyc-stream-listener-sampler
+      # Named into the stack's `wxyc-canary*` namespace, which is the boundary
+      # the CI deploy role is scoped to. A name outside it cannot be deployed by
+      # CI without an out-of-band IAM change — that mismatch rolled back the
+      # first deploy of this function.
+      FunctionName: wxyc-canary-stream-listener-sampler
       Description: Samples WXYC Icecast concurrent listeners every 5 minutes into PostHog.
       CodeUri: dist/
       Handler: stream-sampler-handler.handler


### PR DESCRIPTION
The stream sampler's first deploy (#99, merge `93b3037`) rolled back. This fixes the cause.

## What happened

The CI deploy role is least-privilege and scoped by name — but its **Lambda** and **Logs** statements were pinned to *exact* ARNs (`function:wxyc-canary`, `log-group:/aws/lambda/wxyc-canary:*`) rather than the `wxyc-canary*` prefix the README describes. The new function was named `wxyc-stream-listener-sampler`, outside that boundary, so `lambda:GetFunction` returned `AccessDenied` mid-changeset and CloudFormation rolled the entire stack back.

**Production was never affected.** The rollback was clean: `StreamSamplerFunction` was deleted, `CanaryFunction` was restored to its prior config, and the canary kept running throughout. The damage was a red `main` and no sampler.

Telling detail: the SAM-generated `StreamSamplerFunctionRole` and the EventBridge schedule rule created and deleted *cleanly*, because the `role/wxyc-canary-*` and `rule/wxyc-canary-*` statements were already prefix-wildcards. Only Lambda and Logs were pinned.

## The fix

- **Rename** the function to `wxyc-canary-stream-listener-sampler`, putting it inside the boundary CI can actually deploy. The log group moves with it.
- **Widen** the Lambda and Logs statements to the `wxyc-canary*` prefix, matching the three name-scoped statements that already use it (`role/`, `rule/`, `alarm:`) and matching what the README already claims. Without this, the next function added to this stack reddens `main` identically and needs another out-of-band IAM deploy.

Also documents the constraint in the CI-deploys section, so the next person naming a resource here learns the boundary from the README rather than from a rolled-back deploy.

## Ordering — this matters

The role change lives in the **bootstrap stack**, not this one. CI cannot grant itself the permission it lacks, so the bootstrap stack has to be redeployed with IAM-capable credentials **before** this merges. Merging first just reproduces the same rollback with a different function name.

```sh
aws cloudformation deploy \
  --template-file bootstrap/deploy-role.yaml \
  --stack-name wxyc-canary-deploy \
  --capabilities CAPABILITY_NAMED_IAM \
  --profile wxyc-api --region us-east-1
```

(Stack name is `wxyc-canary-deploy`, per the README's bootstrap section — the template sets `RoleName: wxyc-canary-deploy` explicitly, so a wrong stack name fails on the existing role rather than silently creating a duplicate.)

Then merge, and the deploy on `main` should create the function and start sampling on its first tick.

## Verification

Local gate green: typecheck, `format:check`, 254 tests, `sam validate`. No behavioral change to the sampler itself — this is naming and IAM scope only.

Follow-up to #99 / #98.
