### PR TITLE
Raise the listener sampler to 256 MB for headroom

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -415,7 +415,15 @@ Resources:
       Runtime: nodejs24.x
       Architectures:
         - arm64
-      MemorySize: 128
+      # 256, not the 128 this shipped with. The first production invocation
+      # reported Max Memory Used: 113 MB against a 128 MB ceiling — 88% of the
+      # limit, with the Node 24 runtime itself accounting for most of it. An
+      # OOM here does not fail loudly: the invocation dies before the handler's
+      # structured log line, and since this function publishes no CloudWatch
+      # metrics and owns no alarms, a runtime bump that pushed it over would
+      # silently punch holes in the time series. Lambda bills GB-ms, so at 288
+      # invocations/day of ~3.6s the extra headroom costs cents per year.
+      MemorySize: 256
       # Worst case is THREE HTTP calls, not two: the status read is retried
       # once (8s + 8s) before the failure capture (8s), so 24s of client
       # budget plus cold start and DNS. 30s left almost no margin, and


### PR DESCRIPTION
The stream sampler's first production invocation reported `Max Memory Used: 113 MB` against the 128 MB ceiling it shipped with — **88% of the limit**, with the Node 24 runtime accounting for most of it.

That margin is too thin for a job meant to run unattended for months, and the failure mode is silent rather than loud. An OOM kills the invocation *before* the handler's structured log line, and since this function publishes no CloudWatch metrics and owns no alarms by design, a runtime upgrade that pushed it over would quietly punch holes in the time series with nothing to signal it.

The absence of alarms is deliberate — it measures an audience, it does not assert liveness — but it does mean resource limits have to carry more margin than they would on a monitored function. That asymmetry is the actual argument here, not the 15 MB.

Lambda bills GB-ms, so at 288 invocations/day of ~3.6s each the extra headroom costs cents per year. This also brings it in line with `CanaryFunction`, which has been at 256 MB since the start.

Config only — no behavioral change. Local gate green: typecheck, `format:check`, 254 tests, `sam validate`.

Follow-up to #99.